### PR TITLE
Document required extensions

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -19,7 +19,9 @@
         "runtime": {
             "requires": {
                 "PostgreSQL": "12.0.0",
-                "plpgsql": 0
+                "plpgsql": 0,
+                "pgcrypto": 0,
+                "pg_trgm": 0
             }
         }
     },

--- a/readme.md
+++ b/readme.md
@@ -121,12 +121,16 @@ pg_git/
 ## Dependencies
 - PostgreSQL 12+
 - PL/pgSQL
+- pgcrypto
+- pg_trgm
 
 ## Installation
 ```bash
 make && make install
 
 # In PostgreSQL:
+CREATE EXTENSION pgcrypto;
+CREATE EXTENSION pg_trgm;
 CREATE EXTENSION pg_git;
 ```
 


### PR DESCRIPTION
## Summary
- list `pgcrypto` and `pg_trgm` as runtime requirements
- note these extensions in install steps

## Testing
- `make test` *(fails: pgxs missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f41674f54832894328d0d026cb2e7