### PR TITLE
Initialize HEAD after repository creation

### DIFF
--- a/sql/functions/001-init.sql
+++ b/sql/functions/001-init.sql
@@ -40,6 +40,9 @@ BEGIN
     
     -- Create master branch
     PERFORM update_ref('master', v_initial_commit);
+
+    -- Set HEAD to initial commit so subsequent commands work
+    PERFORM update_ref('HEAD', v_initial_commit);
     
     RETURN v_repo_id;
 END;


### PR DESCRIPTION
## Summary
- update repository initialization to set HEAD

## Testing
- `make test` *(fails: No tests named and `t` directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f41651fd48328b7a7e22dda2c21dc