### PR TITLE
Align version metadata with README

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 EXTENSION = pg_git
-EXTVERSION = 0.2.0
+EXTVERSION = 0.4.0
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/meta.json
+++ b/meta.json
@@ -2,7 +2,7 @@
     "name": "pg_git",
     "abstract": "Git implementation in PostgreSQL",
     "description": "A PostgreSQL extension implementing Git-like version control functionality using native database features",
-    "version": "0.2.0",
+    "version": "0.4.0",
     "maintainer": [
         "Your Name <your.email@example.com>"
     ],
@@ -10,9 +10,9 @@
     "provides": {
         "pg_git": {
             "abstract": "Git implementation in PostgreSQL",
-            "file": "sql/pg_git--0.2.0.sql",
+            "file": "sql/pg_git--0.4.0.sql",
             "docfile": "README.md",
-            "version": "0.2.0"
+            "version": "0.4.0"
         }
     },
     "prereqs": {

--- a/sql/pgit-control.sql
+++ b/sql/pgit-control.sql
@@ -1,5 +1,5 @@
 comment = 'Git implementation in PostgreSQL'
-default_version = '0.2.0'
+default_version = '0.4.0'
 module_pathname = '$libdir/pg_git'
 relocatable = true
 schema = pg_git


### PR DESCRIPTION
## Summary
- bump default extension version to 0.4.0 in control file
- update PGXN meta.json for version 0.4.0
- sync Makefile EXTVERSION with latest version

## Testing
- `make test` *(fails: pgxs.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f416649488328b92b864b09ac23fa