### PR TITLE
Fix duplicate index table

### DIFF
--- a/sql/functions/001-init.sql
+++ b/sql/functions/001-init.sql
@@ -5,14 +5,6 @@ CREATE TABLE repositories (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE index_entries (
-    repo_id INTEGER REFERENCES repositories(id),
-    path TEXT NOT NULL,
-    blob_hash TEXT NOT NULL REFERENCES blobs(hash),
-    staged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, path)
-);
-
 CREATE OR REPLACE FUNCTION init_repository(
     p_name TEXT,
     p_path TEXT

--- a/sql/functions/002-add.sql
+++ b/sql/functions/002-add.sql
@@ -1,12 +1,4 @@
 -- Schema for staging area (index)
-CREATE TABLE index_entries (
-    repo_id INTEGER REFERENCES repositories(id),
-    path TEXT NOT NULL,
-    blob_hash TEXT NOT NULL REFERENCES blobs(hash),
-    mode TEXT NOT NULL DEFAULT '100644',  -- Regular file
-    staged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, path)
-);
 
 -- Function to stage a file
 CREATE OR REPLACE FUNCTION stage_file(

--- a/sql/pgit-version-updates.sql
+++ b/sql/pgit-version-updates.sql
@@ -45,6 +45,7 @@ CREATE SCHEMA pg_git;
 
 -- Load core schema
 \ir ../schema/001-core.sql
+\ir ../schema/pgit-schema.sql
 
 -- Load all functions in order
 \ir ../functions/001-init.sql

--- a/sql/schema/pgit-schema.sql
+++ b/sql/schema/pgit-schema.sql
@@ -1,36 +1,4 @@
--- Path: /sql/schema/001-core.sql
--- Core tables and functions for PGit
-
-CREATE TABLE repositories (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    path TEXT NOT NULL UNIQUE,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE blobs (
-    hash TEXT PRIMARY KEY,
-    content BYTEA NOT NULL
-);
-
-CREATE TABLE trees (
-    hash TEXT PRIMARY KEY,
-    entries JSONB NOT NULL  -- [{mode, type, hash, name}]
-);
-
-CREATE TABLE commits (
-    hash TEXT PRIMARY KEY,
-    tree_hash TEXT NOT NULL REFERENCES trees(hash),
-    parent_hash TEXT REFERENCES commits(hash),
-    author TEXT NOT NULL,
-    message TEXT NOT NULL,
-    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE TABLE refs (
-    name TEXT PRIMARY KEY,
-    commit_hash TEXT NOT NULL REFERENCES commits(hash)
-);
+-- Central schema definitions for PGit
 
 CREATE TABLE index_entries (
     repo_id INTEGER REFERENCES repositories(id),


### PR DESCRIPTION
## Summary
- centralize index_entries table in schema
- drop duplicate CREATE TABLE commands from functions
- load central schema during installation

## Testing
- `make test` *(fails: pgxs.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f4164e3b08328aa1c1d5fd602c2cf