### PR TITLE
Add advanced command tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,8 +8,15 @@ DATA = $(wildcard sql/schema/*.sql) \
        $(wildcard sql/functions/*.sql) \
        $(wildcard sql/updates/*.sql)
 
-TESTS := $(wildcard test/sql/*.sql)
-REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
+TESTS := \
+       test/sql/init.sql \
+       test/sql/add_test.sql \
+       test/sql/branch_test.sql \
+       test/sql/commit_test.sql \
+       test/sql/merge_test.sql \
+       test/sql/remote_test.sql \
+       test/sql/advanced_test.sql
+REGRESS = init add_test branch_test commit_test merge_test remote_test advanced_test
 REGRESS_OPTS = --inputdir=test
 
 MODULES = $(wildcard src/*.c)

--- a/test/sql/advanced_test.sql
+++ b/test/sql/advanced_test.sql
@@ -1,0 +1,70 @@
+-- Path: /test/sql/advanced_test.sql
+-- pg_git advanced command tests
+
+BEGIN;
+
+SELECT plan(10);
+
+-- Setup repository with an initial commit
+SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT pg_git.stage_file(:repo_id, 'test.txt', 'content'::bytea);
+SELECT pg_git.commit_index(:repo_id, 'author', 'init commit');
+
+-- Stash save
+SELECT lives_ok(
+    $$SELECT pg_git.stash_save(:repo_id, 'WIP changes')$$,
+    'Can create stash'
+);
+
+SELECT results_eq(
+    $$SELECT COUNT(*) FROM pg_git.stash WHERE repo_id = :repo_id$$,
+    $$VALUES (1)$$,
+    'Stash record created'
+);
+
+-- Stash pop
+SELECT lives_ok(
+    $$SELECT pg_git.stash_pop(:repo_id)$$,
+    'Can apply stash'
+);
+
+SELECT is_empty(
+    $$SELECT * FROM pg_git.stash WHERE repo_id = :repo_id$$,
+    'Stash cleared after pop'
+);
+
+-- Pack refs
+SELECT lives_ok(
+    $$SELECT pg_git.pack_refs(:repo_id, TRUE)$$,
+    'Can pack refs'
+);
+
+SELECT results_eq(
+    $$SELECT COUNT(*) FROM pg_git.packed_refs WHERE repo_id = :repo_id$$,
+    $$VALUES (1)$$,
+    'Packed refs created'
+);
+
+-- Repack objects
+SELECT lives_ok(
+    $$SELECT * FROM pg_git.repack(:repo_id)$$,
+    'Can repack objects'
+);
+
+-- Blame
+SELECT results_eq(
+    $$SELECT line_content FROM pg_git.blame(:repo_id, 'test.txt') LIMIT 1$$,
+    $$VALUES ('content')$$,
+    'Blame returns line content'
+);
+
+-- Grep
+SELECT results_eq(
+    $$SELECT line_content FROM pg_git.grep(:repo_id, 'content') LIMIT 1$$,
+    $$VALUES ('content')$$,
+    'Grep finds pattern'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+


### PR DESCRIPTION
## Summary
- add regression test for advanced commands (stash, pack, blame, grep, etc.)
- list each test file explicitly in Makefile REGRESS

## Testing
- `make test` *(fails: no pgxs found)*

------
https://chatgpt.com/codex/tasks/task_e_68419824f740832889a3555b2ea65575