### PR TITLE
Add repo scoping to objects

### DIFF
--- a/sql/functions/001-init.sql
+++ b/sql/functions/001-init.sql
@@ -20,10 +20,11 @@ BEGIN
     RETURNING id INTO v_repo_id;
     
     -- Create empty initial tree
-    v_initial_tree := create_tree('[]'::jsonb);
+    v_initial_tree := create_tree(v_repo_id, '[]'::jsonb);
     
     -- Create initial commit
     v_initial_commit := create_commit(
+        v_repo_id,
         v_initial_tree,
         NULL,
         'system',
@@ -31,10 +32,10 @@ BEGIN
     );
     
     -- Create master branch
-    PERFORM update_ref('master', v_initial_commit);
+    PERFORM update_ref(v_repo_id, 'master', v_initial_commit);
 
     -- Set HEAD to initial commit so subsequent commands work
-    PERFORM update_ref('HEAD', v_initial_commit);
+    PERFORM update_ref(v_repo_id, 'HEAD', v_initial_commit);
     
     RETURN v_repo_id;
 END;

--- a/sql/functions/002-add.sql
+++ b/sql/functions/002-add.sql
@@ -11,7 +11,7 @@ DECLARE
     v_blob_hash TEXT;
 BEGIN
     -- Create blob from file content
-    v_blob_hash := create_blob(p_content);
+    v_blob_hash := create_blob(p_repo_id, p_content);
     
     -- Update index
     INSERT INTO index_entries (repo_id, path, blob_hash, mode)

--- a/sql/functions/004-log.sql
+++ b/sql/functions/004-log.sql
@@ -18,19 +18,19 @@ BEGIN
     -- Get HEAD commit
     SELECT commit_hash INTO v_head_commit
     FROM refs
-    WHERE name = 'HEAD';
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
 
     RETURN QUERY
     WITH RECURSIVE commit_log AS (
         SELECT c.*
         FROM commits c
-        WHERE hash = v_head_commit
+        WHERE c.repo_id = p_repo_id AND c.hash = v_head_commit
 
         UNION ALL
 
         SELECT c.*
         FROM commits c
-        INNER JOIN commit_log cl ON c.hash = cl.parent_hash
+        INNER JOIN commit_log cl ON c.repo_id = p_repo_id AND c.hash = cl.parent_hash
     )
     SELECT *
     FROM commit_log
@@ -55,7 +55,7 @@ BEGIN
                c.timestamp,
                array_agg(r.name) as ref_names
         FROM pg_git.get_log(p_repo_id, p_limit) c
-        LEFT JOIN refs r ON c.hash = r.commit_hash
+        LEFT JOIN refs r ON r.repo_id = p_repo_id AND c.hash = r.commit_hash
         GROUP BY c.hash, c.message, c.author, c.timestamp
     )
     SELECT 

--- a/sql/functions/005-status.sql
+++ b/sql/functions/005-status.sql
@@ -15,8 +15,8 @@ BEGIN
     -- Get HEAD commit and tree
     SELECT c.hash, c.tree_hash INTO v_head_commit, v_head_tree
     FROM refs r
-    JOIN commits c ON r.commit_hash = c.hash
-    WHERE r.name = 'HEAD';
+    JOIN commits c ON r.repo_id = p_repo_id AND c.repo_id = r.repo_id AND r.commit_hash = c.hash
+    WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
 
     RETURN QUERY
     -- Staged changes
@@ -35,7 +35,7 @@ BEGIN
         END,
         TRUE
     FROM index_entries i
-    LEFT JOIN trees t ON t.hash = v_head_tree
+    LEFT JOIN trees t ON t.repo_id = p_repo_id AND t.hash = v_head_tree
     WHERE i.repo_id = p_repo_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/functions/007-merge.sql
+++ b/sql/functions/007-merge.sql
@@ -69,17 +69,17 @@ DECLARE
 BEGIN
     -- Get commit hashes
     SELECT commit_hash INTO v_source_commit
-    FROM refs WHERE name = p_source_branch;
+    FROM refs WHERE repo_id = p_repo_id AND name = p_source_branch;
     
     SELECT commit_hash INTO v_target_commit
-    FROM refs WHERE name = p_target_branch;
+    FROM refs WHERE repo_id = p_repo_id AND name = p_target_branch;
     
     -- Check if fast-forward is possible
     IF pg_git.can_fast_forward(v_source_commit, v_target_commit) THEN
         -- Fast-forward merge
-        UPDATE refs 
+        UPDATE refs
         SET commit_hash = v_source_commit
-        WHERE name = p_target_branch;
+        WHERE repo_id = p_repo_id AND name = p_target_branch;
         
         RETURN v_source_commit;
     END IF;

--- a/sql/functions/009-reset.sql
+++ b/sql/functions/009-reset.sql
@@ -7,9 +7,9 @@ CREATE OR REPLACE FUNCTION pg_git.reset_soft(
 ) RETURNS VOID AS $$
 BEGIN
     -- Move HEAD to specified commit
-    UPDATE refs 
+    UPDATE refs
     SET commit_hash = p_commit
-    WHERE name = 'HEAD';
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
 END;
 $$ LANGUAGE plpgsql;
 
@@ -35,13 +35,13 @@ DECLARE
 BEGIN
     -- Get tree from commit
     SELECT tree_hash INTO v_tree_hash
-    FROM commits WHERE hash = p_commit;
+    FROM commits WHERE repo_id = p_repo_id AND hash = p_commit;
     
     -- Get blob hash from tree
     SELECT (e->>'hash')::TEXT INTO v_blob_hash
     FROM trees t,
     jsonb_array_elements(t.entries) e
-    WHERE t.hash = v_tree_hash
+    WHERE t.repo_id = p_repo_id AND t.hash = v_tree_hash
     AND e->>'name' = p_path;
     
     IF v_blob_hash IS NULL THEN

--- a/sql/functions/010-tag.sql
+++ b/sql/functions/010-tag.sql
@@ -24,7 +24,7 @@ BEGIN
     -- Resolve target to commit hash
     IF p_target = 'HEAD' THEN
         SELECT commit_hash INTO v_target_hash
-        FROM refs WHERE name = 'HEAD';
+        FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD';
     ELSE
         v_target_hash := p_target;
     END IF;

--- a/sql/functions/011-remote.sql
+++ b/sql/functions/011-remote.sql
@@ -71,7 +71,7 @@ BEGIN
 
     -- Get local ref
     SELECT commit_hash INTO v_commit_hash
-    FROM refs WHERE name = p_ref_name;
+    FROM refs WHERE repo_id = p_repo_id AND name = p_ref_name;
 
     -- In a real implementation, this would:
     -- 1. Connect to remote database

--- a/sql/schema/001-core.sql
+++ b/sql/schema/001-core.sql
@@ -1,38 +1,50 @@
 -- Core tables
 CREATE TABLE blobs (
-    hash TEXT PRIMARY KEY,
-    content BYTEA NOT NULL
+    repo_id INTEGER REFERENCES repositories(id),
+    hash TEXT,
+    content BYTEA NOT NULL,
+    PRIMARY KEY (repo_id, hash)
 );
 
 CREATE TABLE trees (
-    hash TEXT PRIMARY KEY,
-    entries JSONB NOT NULL  -- [{mode, type, hash, name}]
+    repo_id INTEGER REFERENCES repositories(id),
+    hash TEXT,
+    entries JSONB NOT NULL,  -- [{mode, type, hash, name}]
+    PRIMARY KEY (repo_id, hash)
 );
 
 CREATE TABLE commits (
-    hash TEXT PRIMARY KEY,
-    tree_hash TEXT NOT NULL REFERENCES trees(hash),
-    parent_hash TEXT REFERENCES commits(hash),
+    repo_id INTEGER REFERENCES repositories(id),
+    hash TEXT,
+    tree_hash TEXT NOT NULL,
+    parent_hash TEXT,
     author TEXT NOT NULL,
     message TEXT NOT NULL,
-    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, hash),
+    FOREIGN KEY (repo_id, tree_hash) REFERENCES trees(repo_id, hash),
+    FOREIGN KEY (repo_id, parent_hash) REFERENCES commits(repo_id, hash)
 );
 
 CREATE TABLE refs (
-    name TEXT PRIMARY KEY,
-    commit_hash TEXT NOT NULL REFERENCES commits(hash)
+    repo_id INTEGER REFERENCES repositories(id),
+    name TEXT,
+    commit_hash TEXT NOT NULL,
+    PRIMARY KEY (repo_id, name),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES commits(repo_id, hash)
 );
 
 -- Function to create a blob
 CREATE OR REPLACE FUNCTION create_blob(
+    p_repo_id INTEGER,
     p_content BYTEA
 ) RETURNS TEXT AS $$
 DECLARE
     v_hash TEXT;
 BEGIN
     v_hash := encode(sha256(p_content), 'hex');
-    INSERT INTO blobs (hash, content)
-    VALUES (v_hash, p_content)
+    INSERT INTO blobs (repo_id, hash, content)
+    VALUES (p_repo_id, v_hash, p_content)
     ON CONFLICT DO NOTHING;
     RETURN v_hash;
 END;
@@ -40,14 +52,15 @@ $$ LANGUAGE plpgsql;
 
 -- Function to create a tree
 CREATE OR REPLACE FUNCTION create_tree(
+    p_repo_id INTEGER,
     p_entries JSONB
 ) RETURNS TEXT AS $$
 DECLARE
     v_hash TEXT;
 BEGIN
     v_hash := encode(sha256(p_entries::text::bytea), 'hex');
-    INSERT INTO trees (hash, entries)
-    VALUES (v_hash, p_entries)
+    INSERT INTO trees (repo_id, hash, entries)
+    VALUES (p_repo_id, v_hash, p_entries)
     ON CONFLICT DO NOTHING;
     RETURN v_hash;
 END;
@@ -55,6 +68,7 @@ $$ LANGUAGE plpgsql;
 
 -- Function to create a commit
 CREATE OR REPLACE FUNCTION create_commit(
+    p_repo_id INTEGER,
     p_tree_hash TEXT,
     p_parent_hash TEXT,
     p_author TEXT,
@@ -66,9 +80,9 @@ DECLARE
 BEGIN
     v_commit_data := p_tree_hash || p_parent_hash || p_author || p_message;
     v_hash := encode(sha256(v_commit_data::bytea), 'hex');
-    
-    INSERT INTO commits (hash, tree_hash, parent_hash, author, message)
-    VALUES (v_hash, p_tree_hash, p_parent_hash, p_author, p_message);
+
+    INSERT INTO commits (repo_id, hash, tree_hash, parent_hash, author, message)
+    VALUES (p_repo_id, v_hash, p_tree_hash, p_parent_hash, p_author, p_message);
     
     RETURN v_hash;
 END;
@@ -76,19 +90,21 @@ $$ LANGUAGE plpgsql;
 
 -- Function to create/update a branch
 CREATE OR REPLACE FUNCTION update_ref(
+    p_repo_id INTEGER,
     p_name TEXT,
     p_commit_hash TEXT
 ) RETURNS VOID AS $$
 BEGIN
-    INSERT INTO refs (name, commit_hash)
-    VALUES (p_name, p_commit_hash)
-    ON CONFLICT (name) DO UPDATE
+    INSERT INTO refs (repo_id, name, commit_hash)
+    VALUES (p_repo_id, p_name, p_commit_hash)
+    ON CONFLICT (repo_id, name) DO UPDATE
     SET commit_hash = p_commit_hash;
 END;
 $$ LANGUAGE plpgsql;
 
 -- Function to get commit history
 CREATE OR REPLACE FUNCTION get_commit_history(
+    p_repo_id INTEGER,
     p_start_commit TEXT
 ) RETURNS TABLE (
     hash TEXT,
@@ -99,17 +115,18 @@ CREATE OR REPLACE FUNCTION get_commit_history(
     timestamp TIMESTAMP WITH TIME ZONE
 ) AS $$
 WITH RECURSIVE commit_history AS (
-    SELECT * FROM commits WHERE hash = p_start_commit
+    SELECT * FROM commits WHERE repo_id = p_repo_id AND hash = p_start_commit
     UNION ALL
     SELECT c.*
     FROM commits c
-    INNER JOIN commit_history ch ON c.hash = ch.parent_hash
+    INNER JOIN commit_history ch ON c.repo_id = p_repo_id AND c.hash = ch.parent_hash
 )
 SELECT * FROM commit_history;
 $$ LANGUAGE sql;
 
 -- Function to diff two trees
 CREATE OR REPLACE FUNCTION diff_trees(
+    p_repo_id INTEGER,
     p_old_tree_hash TEXT,
     p_new_tree_hash TEXT
 ) RETURNS TABLE (
@@ -123,8 +140,8 @@ DECLARE
     v_new_entries JSONB;
 BEGIN
     -- Get tree entries
-    SELECT entries INTO v_old_entries FROM trees WHERE hash = p_old_tree_hash;
-    SELECT entries INTO v_new_entries FROM trees WHERE hash = p_new_tree_hash;
+    SELECT entries INTO v_old_entries FROM trees WHERE repo_id = p_repo_id AND hash = p_old_tree_hash;
+    SELECT entries INTO v_new_entries FROM trees WHERE repo_id = p_repo_id AND hash = p_new_tree_hash;
     
     -- Added files
     RETURN QUERY

--- a/test/sql/branch_test.sql
+++ b/test/sql/branch_test.sql
@@ -29,21 +29,21 @@ SELECT lives_ok(
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE name = 'HEAD'$$,
-    $$SELECT commit_hash FROM refs WHERE name = 'test-branch'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'test-branch'$$,
     'HEAD points to correct commit after checkout'
 );
 
 -- Test new branch with start point
 SELECT lives_ok(
     $$SELECT pg_git.create_branch(:repo_id, 'feature-branch', 
-        (SELECT commit_hash FROM refs WHERE name = 'master'))$$,
+        (SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'))$$,
     'Can create branch from specific commit'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE name = 'feature-branch'$$,
-    $$SELECT commit_hash FROM refs WHERE name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'feature-branch'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
     'Branch created at correct commit'
 );
 

--- a/test/sql/commit_test.sql
+++ b/test/sql/commit_test.sql
@@ -16,13 +16,13 @@ SELECT lives_ok(
 );
 
 SELECT results_eq(
-    $$SELECT message FROM commits ORDER BY timestamp DESC LIMIT 1$$,
+    $$SELECT message FROM commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test commit')$$,
     'Commit message stored correctly'
 );
 
 SELECT results_eq(
-    $$SELECT author FROM commits ORDER BY timestamp DESC LIMIT 1$$,
+    $$SELECT author FROM commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test_author')$$,
     'Commit author stored correctly'
 );
@@ -30,7 +30,7 @@ SELECT results_eq(
 -- Test commit tree content
 SELECT results_eq(
     $$SELECT jsonb_array_length(entries) FROM trees t
-    JOIN commits c ON c.tree_hash = t.hash
+    JOIN commits c ON c.repo_id = :repo_id AND c.tree_hash = t.hash AND t.repo_id = :repo_id
     ORDER BY c.timestamp DESC LIMIT 1$$,
     $$VALUES (1)$$,
     'Commit tree has correct number of entries'
@@ -58,7 +58,7 @@ SELECT results_eq(
 
 -- Test parent relationship
 SELECT results_eq(
-    $$SELECT COUNT(*) FROM commits WHERE parent_hash IS NOT NULL$$,
+    $$SELECT COUNT(*) FROM commits WHERE repo_id = :repo_id AND parent_hash IS NOT NULL$$,
     $$VALUES (1)$$,
     'Parent relationship stored correctly'
 );

--- a/test/sql/init.sql
+++ b/test/sql/init.sql
@@ -6,8 +6,9 @@ BEGIN;
 SELECT plan(12);
 
 -- Test repository creation
+SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
 SELECT lives_ok(
-    $$SELECT pg_git.init_repository('test_repo', '/test/path')$$,
+    $$SELECT :repo_id$$,
     'Can create repository'
 );
 
@@ -18,31 +19,31 @@ SELECT results_eq(
 );
 
 SELECT results_eq(
-    $$SELECT name FROM refs WHERE name = 'HEAD'$$,
+    $$SELECT name FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
     $$VALUES ('HEAD')$$,
     'HEAD reference created'
 );
 
 -- Test blob creation
 SELECT lives_ok(
-    $$SELECT pg_git.create_blob('test content'::bytea)$$,
+    $$SELECT pg_git.create_blob(:repo_id, 'test content'::bytea)$$,
     'Can create blob'
 );
 
 SELECT results_eq(
-    $$SELECT encode(content, 'escape') FROM blobs LIMIT 1$$,
+    $$SELECT encode(content, 'escape') FROM blobs WHERE repo_id = :repo_id LIMIT 1$$,
     $$VALUES ('test content')$$,
     'Blob content stored correctly'
 );
 
 -- Test tree creation
 SELECT lives_ok(
-    $$SELECT pg_git.create_tree('[{"mode": "100644", "type": "blob", "hash": "abc", "name": "test.txt"}]'::jsonb)$$,
+    $$SELECT pg_git.create_tree(:repo_id, '[{"mode": "100644", "type": "blob", "hash": "abc", "name": "test.txt"}]'::jsonb)$$,
     'Can create tree'
 );
 
 SELECT results_eq(
-    $$SELECT entries->0->>'name' FROM trees LIMIT 1$$,
+    $$SELECT entries->0->>'name' FROM trees WHERE repo_id = :repo_id LIMIT 1$$,
     $$VALUES ('test.txt')$$,
     'Tree entries stored correctly'
 );
@@ -50,7 +51,8 @@ SELECT results_eq(
 -- Test basic commit
 SELECT lives_ok(
     $$SELECT pg_git.create_commit(
-        (SELECT hash FROM trees LIMIT 1),
+        :repo_id,
+        (SELECT hash FROM trees WHERE repo_id = :repo_id LIMIT 1),
         NULL,
         'test_author',
         'test commit'
@@ -59,25 +61,25 @@ SELECT lives_ok(
 );
 
 SELECT results_eq(
-    $$SELECT message FROM commits LIMIT 1$$,
+    $$SELECT message FROM commits WHERE repo_id = :repo_id LIMIT 1$$,
     $$VALUES ('test commit')$$,
     'Commit message stored correctly'
 );
 
 SELECT results_eq(
-    $$SELECT author FROM commits LIMIT 1$$,
+    $$SELECT author FROM commits WHERE repo_id = :repo_id LIMIT 1$$,
     $$VALUES ('test_author')$$,
     'Commit author stored correctly'
 );
 
 -- Test refs
 SELECT lives_ok(
-    $$SELECT pg_git.update_ref('test_branch', (SELECT hash FROM commits LIMIT 1))$$,
+    $$SELECT pg_git.update_ref(:repo_id, 'test_branch', (SELECT hash FROM commits WHERE repo_id = :repo_id LIMIT 1))$$,
     'Can create branch reference'
 );
 
 SELECT results_eq(
-    $$SELECT name FROM refs WHERE name = 'test_branch'$$,
+    $$SELECT name FROM refs WHERE repo_id = :repo_id AND name = 'test_branch'$$,
     $$VALUES ('test_branch')$$,
     'Branch reference created correctly'
 );

--- a/test/sql/merge_test.sql
+++ b/test/sql/merge_test.sql
@@ -37,14 +37,14 @@ SELECT lives_ok(
 
 -- Test HEAD after merge
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE name = 'HEAD'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
     $$SELECT :feature_commit$$,
     'HEAD points to correct commit after merge'
 );
 
 -- Test branch pointer after merge
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
     $$SELECT :feature_commit$$,
     'Branch points to correct commit after merge'
 );


### PR DESCRIPTION
## Summary
- add `repo_id` to core objects and functions
- update repository utilities to use repo scoping
- adjust plumbing helpers for repo awareness
- revise tests for per-repository data

## Testing
- `make test` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk'.)*

------
https://chatgpt.com/codex/tasks/task_e_6841982787c8832898b6a559ef656205