### PR TITLE
Add extension control and base script

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -4,7 +4,7 @@
     "description": "A PostgreSQL extension implementing Git-like version control functionality using native database features",
     "version": "0.4.0",
     "maintainer": [
-        "Your Name <your.email@example.com>"
+        "pg_git maintainers <your.email@example.com>"
     ],
     "license": "postgresql",
     "provides": {
@@ -32,7 +32,7 @@
             "type": "git"
         }
     },
-    "generated_by": "Your Name",
+    "generated_by": "pg_git maintainers",
     "meta-spec": {
         "version": "1.0.0",
         "url": "https://pgxn.org/meta/spec.txt"

--- a/pg_git.control
+++ b/pg_git.control
@@ -1,0 +1,4 @@
+comment = 'Git implementation in PostgreSQL'
+default_version = '0.4.0'
+module_pathname = '$libdir/pg_git'
+requires = 'plpgsql,pgcrypto,pg_trgm'

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -1,0 +1,45 @@
+-- pg_git extension version 0.4.0
+
+CREATE SCHEMA pg_git;
+
+-- Core schema
+\ir schema/001-core.sql
+\ir schema/pgit-schema.sql
+
+-- Core functions
+\ir functions/001-init.sql
+\ir functions/002-add.sql
+\ir functions/003-commit.sql
+\ir functions/004-log.sql
+\ir functions/005-status.sql
+\ir functions/006-branch.sql
+\ir functions/007-merge.sql
+\ir functions/008-diff.sql
+\ir functions/009-reset.sql
+\ir functions/010-tag.sql
+\ir functions/011-remote.sql
+
+-- Additional features
+\ir functions/012-migrations.sql
+\ir functions/013-merge-conflicts.sql
+\ir functions/014-https.sql
+\ir functions/015-admin.sql
+\ir pgit-advanced-commands.sql
+\ir pgit-plumbing.sql
+\ir pgit-extras.sql
+
+-- Version 0.4 additions
+\ir pgit-archive.sql
+\ir pgit-submodule.sql
+\ir pgit-sparse.sql
+\ir pgit-merge-tree.sql
+\ir pgit-rerere.sql
+\ir pgit-diagnose.sql
+\ir pgit-verify-commit.sql
+\ir pgit-verify-tag.sql
+\ir pgit-whatchanged.sql
+\ir pgit-instaweb.sql
+\ir pgit-pack-refs.sql
+\ir pgit-repack.sql
+\ir pgit-replace.sql
+


### PR DESCRIPTION
## Summary
- add `pg_git.control` describing the extension
- load schema and functions with `pg_git--0.4.0.sql`
- update maintainer metadata

## Testing
- `make test` *(fails: pgxs.mk missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff550d1c83289dbbe8483c0f1645