### PR TITLE
Fix extension control file

### DIFF
--- a/pg_git.control
+++ b/pg_git.control
@@ -1,7 +1,6 @@
 comment = 'Git implementation in PostgreSQL'
 default_version = '0.4.0'
 schema = pg_git
-requires = 'plpgsql'
 relocatable = true
 module_pathname = '$libdir/pg_git'
 requires = 'plpgsql,pgcrypto,pg_trgm'


### PR DESCRIPTION
## Summary
- remove duplicate `requires` line from `pg_git.control`

## Testing
- `make test` *(fails: pgxs.mk missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d649644a48328aff3c907ef1741f9