### PR TITLE
Implement encrypted credentials and HTTP fetch

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -21,7 +21,8 @@
                 "PostgreSQL": "12.0.0",
                 "plpgsql": 0,
                 "pgcrypto": 0,
-                "pg_trgm": 0
+                "pg_trgm": 0,
+                "plpython3u": 0
             }
         }
     },
@@ -44,3 +45,4 @@
         "repository"
     ]
 }
+

--- a/pg_git.control
+++ b/pg_git.control
@@ -1,8 +1,7 @@
 comment = 'Git implementation in PostgreSQL'
 default_version = '0.4.0'
 schema = pg_git
-requires = 'plpgsql'
 relocatable = true
 module_pathname = '$libdir/pg_git'
-requires = 'plpgsql,pgcrypto,pg_trgm'
+requires = 'plpgsql,pgcrypto,pg_trgm,plpython3u'
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ A PostgreSQL-native Git implementation.
 - Instaweb interface
 - Pack and repack support
 - Object replacement
-- Remote operations with HTTPS transport
+ - Remote operations with HTTPS transport (uses `plpython3u`)
 - Stash management
 - Worktree support
 - Bisect debugging
@@ -187,7 +187,11 @@ SELECT pg_git.create_branch(1, 'feature');
 SELECT pg_git.merge_branches(1, 'feature', 'main');
 
 -- Remote operations with HTTPS
+-- Set encryption key for storing credentials
+ALTER SYSTEM SET pg_git.credential_key = 'my_secret';
+SELECT pg_reload_conf();
 SELECT pg_git.store_credentials(1, 'github.com', 'username', 'token');
+-- `http_fetch` uses Python to perform the actual HTTPS request
 
 -- Garbage collection
 SELECT pg_git.gc(1, aggressive := true);
@@ -226,3 +230,4 @@ Current: 0.4.0
 
 ## License
 See [LICENSE](LICENSE) for the full text of the PostgreSQL License.
+

--- a/sql/functions/014-https.sql
+++ b/sql/functions/014-https.sql
@@ -5,7 +5,7 @@ CREATE TABLE pg_git.credentials (
     repo_id INTEGER REFERENCES repositories(id),
     host TEXT NOT NULL,
     username TEXT NOT NULL,
-    password TEXT NOT NULL,
+    password BYTEA NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, host)
 );
@@ -16,12 +16,19 @@ CREATE OR REPLACE FUNCTION pg_git.store_credentials(
     p_username TEXT,
     p_password TEXT
 ) RETURNS VOID AS $$
+DECLARE
+    v_key TEXT := current_setting('pg_git.credential_key', true);
 BEGIN
     INSERT INTO pg_git.credentials (repo_id, host, username, password)
-    VALUES (p_repo_id, p_host, p_username, pgcrypto.crypt(p_password, pgcrypto.gen_salt('bf')))
+    VALUES (
+        p_repo_id,
+        p_host,
+        p_username,
+        pgp_sym_encrypt(p_password, coalesce(v_key, 'pg_git_default_key'))
+    )
     ON CONFLICT (repo_id, host) DO UPDATE
     SET username = EXCLUDED.username,
-        password = pgcrypto.crypt(p_password, pgcrypto.gen_salt('bf'));
+        password = pgp_sym_encrypt(p_password, coalesce(v_key, 'pg_git_default_key'));
 END;
 $$ LANGUAGE plpgsql;
 
@@ -29,26 +36,28 @@ CREATE OR REPLACE FUNCTION pg_git.http_fetch(
     p_repo_id INTEGER,
     p_url TEXT,
     p_ref TEXT
-) RETURNS BYTEA AS $$
-DECLARE
-    v_host TEXT;
-    v_username TEXT;
-    v_password TEXT;
-    v_response BYTEA;
-BEGIN
-    -- Extract host from URL
-    v_host := regexp_replace(p_url, '^https?://([^/]+).*', '\1');
-    
-    -- Get credentials if stored
-    SELECT username, password 
-    INTO v_username, v_password
-    FROM pg_git.credentials
-    WHERE repo_id = p_repo_id AND host = v_host;
-    
-    -- Here you would implement actual HTTPS request
-    -- This is a placeholder for the actual implementation
-    RAISE NOTICE 'Would fetch % with credentials for %', p_url, v_host;
-    
-    RETURN v_response;
-END;
-$$ LANGUAGE plpgsql;
+) RETURNS BYTEA AS $$import base64
+from urllib.parse import urlparse
+import urllib.request
+
+host = urlparse(p_url).hostname
+key = plpy.execute("SELECT current_setting('pg_git.credential_key', true) AS k")[0]['k'] or 'pg_git_default_key'
+cred = plpy.execute(
+    "SELECT username, pgp_sym_decrypt(password, $1) AS pw FROM pg_git.credentials WHERE repo_id = $2 AND host = $3",
+    [key, p_repo_id, host]
+)
+
+username = cred[0]['username'] if cred else None
+password = cred[0]['pw'] if cred else None
+
+req = urllib.request.Request(p_url)
+if username:
+    token = f"{username}:{password}".encode('utf-8')
+    req.add_header('Authorization', 'Basic ' + base64.b64encode(token).decode('ascii'))
+
+with urllib.request.urlopen(req) as resp:
+    data = resp.read()
+
+return data
+$$ LANGUAGE plpython3u;
+


### PR DESCRIPTION
## Summary
- encrypt stored credentials using pgcrypto
- add plpython3u-based HTTP fetch implementation
- document credential handling in README
- require plpython3u in extension files

## Testing
- `make test` *(fails: pgxs missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d64999b5483289bfebf530633a9c2