### PR TITLE
Fix repository URLs in meta.json

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -27,8 +27,8 @@
     },
     "resources": {
         "repository": {
-            "url": "https://github.com/yourusername/pg_git.git",
-            "web": "https://github.com/yourusername/pg_git",
+            "url": "https://github.com/seanwevans/pg_git.git",
+            "web": "https://github.com/seanwevans/pg_git",
             "type": "git"
         }
     },


### PR DESCRIPTION
## Summary
- replace placeholder links in `meta.json` with the actual repository URLs

## Testing
- `make test` *(fails: pgxs.mk not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d649ab4e88328814d05248cd9510e