### PR TITLE
Handle optional credentials in http_fetch and add tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,8 +16,9 @@ TESTS := \
        test/sql/commit_test.sql \
        test/sql/merge_test.sql \
        test/sql/remote_test.sql \
+       test/sql/https_fetch_test.sql \
        test/sql/advanced_test.sql
-REGRESS = init add_test branch_test commit_test merge_test remote_test advanced_test
+REGRESS = init add_test branch_test commit_test merge_test remote_test https_fetch_test advanced_test
 REGRESS_OPTS = --inputdir=test
 
 include $(PGXS)

--- a/sql/functions/014-https.sql
+++ b/sql/functions/014-https.sql
@@ -34,8 +34,7 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pg_git.http_fetch(
     p_repo_id INTEGER,
-    p_url TEXT,
-    p_ref TEXT
+    p_url TEXT
 ) RETURNS BYTEA AS $$import base64
 from urllib.parse import urlparse
 import urllib.request
@@ -47,8 +46,11 @@ cred = plpy.execute(
     [key, p_repo_id, host]
 )
 
-username = cred[0]['username'] if cred else None
-password = cred[0]['pw'] if cred else None
+username = None
+password = None
+if len(cred) > 0:
+    username = cred[0]['username']
+    password = cred[0]['pw']
 
 req = urllib.request.Request(p_url)
 if username:

--- a/test/sql/https_fetch_test.sql
+++ b/test/sql/https_fetch_test.sql
@@ -1,0 +1,28 @@
+-- Path: /test/sql/https_fetch_test.sql
+-- Tests for pg_git.http_fetch authentication handling
+
+BEGIN;
+
+SELECT plan(2);
+
+-- Setup test repository
+SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+
+-- Unauthenticated fetch should succeed without stored credentials
+SELECT like(
+    encode(pg_git.http_fetch(:repo_id, 'https://httpbin.org/get'), 'escape'),
+    '%"url": "https://httpbin.org/get"%',
+    'Unauthenticated fetch returns expected content'
+);
+
+-- Authenticated fetch using stored credentials
+SET pg_git.credential_key = 'test_key';
+SELECT pg_git.store_credentials(:repo_id, 'httpbin.org', 'user', 'pass');
+SELECT like(
+    encode(pg_git.http_fetch(:repo_id, 'https://httpbin.org/basic-auth/user/pass'), 'escape'),
+    '%"authenticated": true%',
+    'Authenticated fetch returns expected content'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- avoid indexing missing credential rows in `pg_git.http_fetch`
- drop unused `p_ref` parameter
- add tests for authenticated and unauthenticated HTTP fetch

## Testing
- `make test` *(fails: schema "pg_git" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68939751f788832888110e76ad4bdf9f