### PR TITLE
Update commit_index to move branch refs

### DIFF
--- a/sql/functions/003-commit.sql
+++ b/sql/functions/003-commit.sql
@@ -49,8 +49,13 @@ BEGIN
         p_message
     );
 
-    -- Update HEAD and current branch
+    -- Update HEAD and branch reference
     UPDATE refs SET commit_hash = v_commit_hash WHERE repo_id = p_repo_id AND name = 'HEAD';
+    UPDATE refs
+    SET commit_hash = v_commit_hash
+    WHERE repo_id = p_repo_id
+      AND commit_hash = v_parent_hash
+      AND name <> 'HEAD';
 
     -- Clear index
     DELETE FROM index_entries WHERE repo_id = p_repo_id;

--- a/test/sql/commit_test.sql
+++ b/test/sql/commit_test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(9);
 
 -- Setup test repository and staged file
 SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
@@ -25,6 +25,12 @@ SELECT results_eq(
     $$SELECT author FROM commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test_author')$$,
     'Commit author stored correctly'
+);
+
+SELECT results_eq(
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
+    'Branch reference moves to new commit'
 );
 
 -- Test commit tree content


### PR DESCRIPTION
## Summary
- ensure commit_index updates HEAD and branch refs to new commit
- test that branch ref advances with commit

## Testing
- `make test` *(fails: schema "pg_git" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68939750c00c8328a52e2d2c20d8b207