### PR TITLE
Improve optimize_indexes error handling and add tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,8 +18,9 @@ TESTS := \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
        test/sql/gc_test.sql \
-       test/sql/https_fetch_test.sql
-REGRESS = init add_test branch_test commit_test merge_test remote_test advanced_test gc_test https_fetch_test 
+       test/sql/https_fetch_test.sql \
+       test/sql/optimize_indexes_test.sql
+REGRESS = init add_test branch_test commit_test merge_test remote_test advanced_test gc_test https_fetch_test optimize_indexes_test
 
 REGRESS_OPTS = --inputdir=test
 

--- a/sql/functions/015-admin.sql
+++ b/sql/functions/015-admin.sql
@@ -112,27 +112,39 @@ CREATE OR REPLACE FUNCTION pg_git.optimize_indexes(
 ) RETURNS TABLE (
     table_name TEXT,
     index_name TEXT,
-    operation TEXT
+    operation TEXT,
+    success BOOLEAN
 ) AS $$
 BEGIN
-    RETURN QUERY
-    SELECT t.tablename::TEXT,
-           i.indexname::TEXT,
-           'REINDEX'::TEXT
-    FROM pg_tables t
-    JOIN pg_indexes i ON i.tablename = t.tablename
-    WHERE t.schemaname = 'pg_git'
-    ORDER BY t.tablename, i.indexname;
-    
-    -- Actually perform the reindex
-    FOR table_name, index_name, operation IN
+    -- Temporary table to collect reindex results
+    CREATE TEMP TABLE IF NOT EXISTS optimize_index_results (
+        table_name TEXT,
+        index_name TEXT,
+        operation TEXT,
+        success BOOLEAN
+    ) ON COMMIT DROP;
+    TRUNCATE optimize_index_results;
+
+    -- Perform reindex operations, logging successes and failures
+    FOR table_name, index_name IN
         SELECT t.tablename::TEXT,
-               i.indexname::TEXT,
-               'REINDEX'::TEXT
+               i.indexname::TEXT
         FROM pg_tables t
         JOIN pg_indexes i ON i.tablename = t.tablename
         WHERE t.schemaname = 'pg_git'
     LOOP
-        EXECUTE format('REINDEX INDEX %I', index_name);
+        BEGIN
+            EXECUTE format('REINDEX INDEX %I', index_name);
+            INSERT INTO optimize_index_results VALUES (table_name, index_name, 'REINDEX', TRUE);
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'Reindex failed for %: %', index_name, SQLERRM;
+            INSERT INTO optimize_index_results VALUES (table_name, index_name, 'REINDEX', FALSE);
+        END;
     END LOOP;
+
+    -- Return results to caller
+    RETURN QUERY
+    SELECT table_name, index_name, operation, success
+    FROM optimize_index_results
+    ORDER BY table_name, index_name;
 END;$$ LANGUAGE plpgsql;

--- a/test/sql/optimize_indexes_test.sql
+++ b/test/sql/optimize_indexes_test.sql
@@ -1,0 +1,52 @@
+-- Path: /test/sql/optimize_indexes_test.sql
+-- pg_git optimize indexes tests
+
+BEGIN;
+
+SELECT plan(3);
+
+-- Initialize repository
+SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset;
+
+-- Determine expected number of indexes
+SELECT count(*) AS total_indexes
+FROM pg_indexes i
+JOIN pg_tables t ON i.tablename = t.tablename
+WHERE t.schemaname = 'pg_git'
+\gset
+
+-- Successful reindex run
+SELECT results_eq(
+    $$SELECT count(*) FROM pg_git.optimize_indexes(:repo_id)$$,
+    $$SELECT :total_indexes$$,
+    'Returned one row per index'
+);
+
+SELECT is_empty(
+    $$SELECT * FROM pg_git.optimize_indexes(:repo_id) WHERE NOT success$$,
+    'All indexes reindexed successfully'
+);
+
+-- Setup failure to simulate errors
+CREATE OR REPLACE FUNCTION fail_all_reindex() RETURNS event_trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'simulated failure';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EVENT TRIGGER fail_reindex
+    ON ddl_command_start
+    WHEN TAG IN ('REINDEX INDEX')
+    EXECUTE PROCEDURE fail_all_reindex();
+
+-- Failure scenario run
+SELECT is_empty(
+    $$SELECT * FROM pg_git.optimize_indexes(:repo_id) WHERE success$$,
+    'Reindex failures captured'
+);
+
+DROP EVENT TRIGGER fail_reindex;
+DROP FUNCTION fail_all_reindex();
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- track REINDEX success or failure per index in `pg_git.optimize_indexes`
- return actual outcomes after reindexing
- add regression tests for optimize_indexes

## Testing
- `make test` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')*

------
https://chatgpt.com/codex/tasks/task_e_689d27b377908328a378ad975e5a0209