### PR TITLE
Normalize staged paths and add tests

### DIFF
--- a/sql/functions/002-add.sql
+++ b/sql/functions/002-add.sql
@@ -1,4 +1,38 @@
+
 -- Schema for staging area (index)
+
+-- Helper function to normalize file paths and prevent traversal
+CREATE OR REPLACE FUNCTION normalize_path(p_path TEXT)
+RETURNS TEXT AS $$
+DECLARE
+    v_parts TEXT[];
+    v_stack TEXT[] := ARRAY[]::TEXT[];
+    v_part TEXT;
+BEGIN
+    -- Reject absolute paths
+    IF p_path LIKE '/%' THEN
+        RAISE EXCEPTION 'Absolute paths are not allowed: %', p_path;
+    END IF;
+
+    -- Split and process path components
+    v_parts := regexp_split_to_array(p_path, '/+');
+    FOREACH v_part IN ARRAY v_parts LOOP
+        IF v_part = '' OR v_part = '.' THEN
+            CONTINUE;
+        ELSIF v_part = '..' THEN
+            -- Prevent traversing above repository root
+            IF array_length(v_stack, 1) IS NULL THEN
+                RAISE EXCEPTION 'Path traversal is not allowed: %', p_path;
+            END IF;
+            v_stack := v_stack[1:array_length(v_stack,1)-1];
+        ELSE
+            v_stack := v_stack || v_part;
+        END IF;
+    END LOOP;
+
+    RETURN array_to_string(v_stack, '/');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
 
 -- Function to stage a file
 CREATE OR REPLACE FUNCTION stage_file(
@@ -9,16 +43,20 @@ CREATE OR REPLACE FUNCTION stage_file(
 ) RETURNS TEXT AS $$
 DECLARE
     v_blob_hash TEXT;
+    v_norm_path TEXT;
 BEGIN
+    -- Normalize and validate path
+    v_norm_path := normalize_path(p_path);
+
     -- Create blob from file content
     v_blob_hash := create_blob(p_repo_id, p_content);
-    
+
     -- Update index
     INSERT INTO index_entries (repo_id, path, blob_hash, mode)
-    VALUES (p_repo_id, p_path, v_blob_hash, p_mode)
-    ON CONFLICT (repo_id, path) 
-    DO UPDATE SET blob_hash = v_blob_hash, staged_at = CURRENT_TIMESTAMP;
-    
+    VALUES (p_repo_id, v_norm_path, v_blob_hash, p_mode)
+    ON CONFLICT (repo_id, path)
+    DO UPDATE SET blob_hash = v_blob_hash, path = EXCLUDED.path, staged_at = CURRENT_TIMESTAMP;
+
     RETURN v_blob_hash;
 END;
 $$ LANGUAGE plpgsql;

--- a/test/sql/add_test.sql
+++ b/test/sql/add_test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(6);
+SELECT plan(10);
 
 -- Setup test repository
 SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
@@ -43,6 +43,32 @@ SELECT lives_ok(
 SELECT is_empty(
     $$SELECT * FROM index_entries WHERE repo_id = :repo_id$$,
     'Index cleared after unstage'
+);
+
+-- Test path normalization
+SELECT lives_ok(
+    $$SELECT pg_git.stage_file(:repo_id, 'dir/./sub/../file.txt', 'norm content'::bytea)$$,
+    'Stages file with normalized path'
+);
+
+SELECT results_eq(
+    $$SELECT path FROM index_entries WHERE repo_id = :repo_id$$,
+    $$VALUES ('dir/file.txt')$$,
+    'Normalized path stored correctly'
+);
+
+-- Test rejection of path traversal
+SELECT throws_ok(
+    $$SELECT pg_git.stage_file(:repo_id, '../evil.txt', 'x'::bytea)$$,
+    'Path traversal is not allowed',
+    'Rejects path traversal'
+);
+
+-- Test rejection of absolute paths
+SELECT throws_ok(
+    $$SELECT pg_git.stage_file(:repo_id, '/etc/passwd', 'x'::bytea)$$,
+    'Absolute paths are not allowed',
+    'Rejects absolute paths'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- normalize stage_file paths and reject traversal
- test path normalization and malicious path handling

## Testing
- `make test` *(fails: schema "pg_git" does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689d27b28bdc8328942e13023e9f3216