### PR TITLE
Install pgTAP for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     postgresql-server-dev-all \
     git \
+    postgresql-${PG_MAJOR}-pgtap \
+    libtap-parser-sourcehandler-pgtap-perl \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /pg_git


### PR DESCRIPTION
## Summary
- ensure pg_prove is available during CI builds

## Testing
- `docker-compose up --abort-on-container-exit --exit-code-from test test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689fb47750e0832880de31fbab6bd90e