### PR TITLE
Derive regression targets from test files

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,9 +20,11 @@ TESTS := \
        test/sql/gc_test.sql \
        test/sql/https_fetch_test.sql \
        test/sql/optimize_indexes_test.sql \
-       test/sql/gc_performance_test.sql       
+       test/sql/gc_performance_test.sql
 
-REGRESS = init add_test branch_test commit_test merge_test remote_test advanced_test gc_test gc_performance_test https_fetch_test optimize_indexes_test
+# Ensure a corresponding REGRESS target exists for every SQL test file.
+# Derive the target names from the TESTS list to keep them in sync.
+REGRESS := $(notdir $(basename $(TESTS)))
 
 REGRESS_OPTS = --inputdir=test
 


### PR DESCRIPTION
## Summary
- derive regression target list from test files to keep TESTS and REGRESS aligned

## Testing
- `make test` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')*


------
https://chatgpt.com/codex/tasks/task_e_689fbc56987c832897912b41665b9e63