### PR TITLE
Install PL/Python dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     postgresql-server-dev-all \
     git \
     postgresql-${PG_MAJOR}-pgtap \
+    postgresql-${PG_MAJOR}-plpython3 \
     libtap-parser-sourcehandler-pgtap-perl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- add postgresql-${PG_MAJOR}-plpython3 to Docker build to ensure PL/Python is available

## Testing
- `docker-compose build` *(fails: Error while fetching server API version: Connection aborted - FileNotFoundError)*
- `make && make install`
- `make test` *(fails: pg_prove: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fbc5537688328af6d87b6ec20bda3