### PR TITLE
Remove module_pathname from control file

### DIFF
--- a/pg_git.control
+++ b/pg_git.control
@@ -2,6 +2,5 @@ comment = 'Git implementation in PostgreSQL'
 default_version = '0.4.0'
 schema = pg_git
 relocatable = true
-module_pathname = '$libdir/pg_git'
 requires = 'plpgsql,pgcrypto,pg_trgm,plpython3u'
 


### PR DESCRIPTION
## Summary
- remove module_pathname from pg_git.control since pg_git contains only SQL and script code

## Testing
- `make`
- `make test` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fbc53451c83288ed9e13ed3de62d1