### PR TITLE
Wait for PostgreSQL before running tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,17 +11,23 @@ services:
     volumes:
       - .:/pg_git
       - pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   test:
     build: .
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       PGHOST: db
       PGUSER: postgres
       PGPASSWORD: postgres
       PGDATABASE: pg_git_dev
-    command: make test
+    command: ["./wait-for-db.sh", "make", "test"]
 
 volumes:
   pg_data:

--- a/wait-for-db.sh
+++ b/wait-for-db.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+HOST="${PGHOST:-db}"
+PORT="${PGPORT:-5432}"
+
+until pg_isready -h "$HOST" -p "$PORT"; do
+  echo "Waiting for PostgreSQL at $HOST:$PORT..."
+  sleep 2
+done
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add healthcheck to the PostgreSQL service
- add wait-for-db script and use it in test service

## Testing
- `make test` *(fails: No rule to make target '/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk')*

------
https://chatgpt.com/codex/tasks/task_e_689fc3fae9688328a4b33f64c159c1ee