### PR TITLE
Ensure pgTAP extension installed for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     postgresql-server-dev-all \
     git \
-    postgresql-15-pgtap \
-    postgresql-plpython3-15 \
+    postgresql-14-pgtap \
+    postgresql-plpython3-14 \
     libtap-parser-sourcehandler-pgtap-perl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/test/sql/init.sql
+++ b/test/sql/init.sql
@@ -1,6 +1,8 @@
 -- Path: /test/sql/init.sql
 -- pg_git initialization tests
 
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
 BEGIN;
 
 SELECT plan(12);


### PR DESCRIPTION
## Summary
- install PostgreSQL 14 pgTAP and plpython packages in Docker image
- load pgTAP in test initialization to provide `plan()` and related functions

## Testing
- `make test` *(fails: /usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fc809ddc48328a354965626500af4