### PR TITLE
Install pg_git extension before running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Build and install extension
+        run: |
+          make
+          sudo make install
       - name: Run tests
         run: |
           docker compose up --abort-on-container-exit --exit-code-from test test

--- a/test/sql/init.sql
+++ b/test/sql/init.sql
@@ -2,6 +2,7 @@
 -- pg_git initialization tests
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
+CREATE EXTENSION IF NOT EXISTS pg_git;
 
 BEGIN;
 


### PR DESCRIPTION
## Summary
- Build and install pg_git extension prior to running CI tests
- Ensure tests load the pg_git extension before exercising functionality

## Testing
- `docker compose up --abort-on-container-exit --exit-code-from test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fcd22843c83289550832a01ea28da