### PR TITLE
Ensure pg_git builds against PostgreSQL 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:14
 
 RUN apt-get update && apt-get install -y \
     build-essential \
-    postgresql-server-dev-all \
+    postgresql-server-dev-14 \
     git \
     postgresql-14-pgtap \
     postgresql-plpython3-14 \
@@ -13,4 +13,5 @@ WORKDIR /pg_git
 
 COPY . .
 
-RUN make && make install
+RUN make PG_CONFIG=/usr/lib/postgresql/14/bin/pg_config && \
+    make PG_CONFIG=/usr/lib/postgresql/14/bin/pg_config install


### PR DESCRIPTION
## Summary
- install PostgreSQL 14 development packages in Docker build
- compile and install using pg_config from PostgreSQL 14

## Testing
- `sudo -u postgres make test` *(fails: parameter "schema" cannot be specified when "relocatable" is true)*

------
https://chatgpt.com/codex/tasks/task_e_689fce8fbadc832896316073f2b75141