### PR TITLE
Normalize path in unstage_file

### DIFF
--- a/sql/functions/002-add.sql
+++ b/sql/functions/002-add.sql
@@ -66,7 +66,11 @@ CREATE OR REPLACE FUNCTION unstage_file(
     p_repo_id INTEGER,
     p_path TEXT
 ) RETURNS VOID AS $$
+DECLARE
+    v_norm_path TEXT;
 BEGIN
-    DELETE FROM index_entries 
-    WHERE repo_id = p_repo_id AND path = p_path;
+    v_norm_path := normalize_path(p_path);
+
+    DELETE FROM index_entries
+    WHERE repo_id = p_repo_id AND path = v_norm_path;
 END;$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary
- normalize paths in `unstage_file` to match staging behavior
- delete staged entries using the normalized path value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b23d852083288eac37f9602ba919