### PR TITLE
Ensure deterministic tree entry ordering

### DIFF
--- a/sql/functions/003-commit.sql
+++ b/sql/functions/003-commit.sql
@@ -15,8 +15,12 @@ BEGIN
             'name', path
         )
     ) INTO v_entries
-    FROM index_entries
-    WHERE repo_id = p_repo_id;
+    FROM (
+        SELECT mode, blob_hash, path
+        FROM index_entries
+        WHERE repo_id = p_repo_id
+        ORDER BY path
+    ) ordered_entries;
 
     RETURN pg_git.create_tree(p_repo_id, COALESCE(v_entries, '[]'::jsonb));
 END;


### PR DESCRIPTION
## Summary
- wrap the index entry selection for `create_tree_from_index` in an ordered subquery to provide deterministic JSON aggregation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b23e23f88328a7ba072c1c496ab5