### PR TITLE
Adjust index_entries blob foreign key declaration

### DIFF
--- a/sql/schema/pgit-schema.sql
+++ b/sql/schema/pgit-schema.sql
@@ -3,7 +3,8 @@
 CREATE TABLE index_entries (
     repo_id INTEGER REFERENCES repositories(id),
     path TEXT NOT NULL,
-    blob_hash TEXT NOT NULL REFERENCES blobs(hash),
+    blob_hash TEXT NOT NULL,
     mode TEXT NOT NULL DEFAULT '100644',
     staged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (repo_id, blob_hash) REFERENCES pg_git.blobs(repo_id, hash),
     PRIMARY KEY (repo_id, path));


### PR DESCRIPTION
## Summary
- remove the inline foreign key reference on `blob_hash` in `index_entries`
- add an explicit foreign key definition referencing `pg_git.blobs`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6b23cd3608328903c87bb6db4c688