### PR TITLE
Scope merge ancestry helpers by repo ID

### DIFF
--- a/sql/functions/007-merge.sql
+++ b/sql/functions/007-merge.sql
@@ -2,6 +2,7 @@
 -- pg_git merge operations
 
 CREATE OR REPLACE FUNCTION pg_git.find_merge_base(
+    p_repo_id INTEGER,
     p_commit1 TEXT,
     p_commit2 TEXT
 ) RETURNS TEXT AS $$
@@ -9,24 +10,24 @@ WITH RECURSIVE commit_ancestors AS (
     -- Get all ancestors of commit1
     SELECT hash, parent_hash, 1 AS source
     FROM commits 
-    WHERE hash = p_commit1
+    WHERE repo_id = p_repo_id AND hash = p_commit1
     UNION ALL
     SELECT c.hash, c.parent_hash, 1
     FROM commits c
     JOIN commit_ancestors ca ON ca.parent_hash = c.hash
-    WHERE ca.source = 1
+    WHERE ca.source = 1 AND c.repo_id = p_repo_id
 
     UNION ALL
 
     -- Get all ancestors of commit2
     SELECT hash, parent_hash, 2 AS source
     FROM commits 
-    WHERE hash = p_commit2
+    WHERE repo_id = p_repo_id AND hash = p_commit2
     UNION ALL
     SELECT c.hash, c.parent_hash, 2
     FROM commits c
     JOIN commit_ancestors ca ON ca.parent_hash = c.hash
-    WHERE ca.source = 2
+    WHERE ca.source = 2 AND c.repo_id = p_repo_id
 )
 SELECT hash
 FROM (
@@ -35,22 +36,23 @@ FROM (
     GROUP BY hash
 ) a
 WHERE array_length(sources, 1) > 1
-ORDER BY (SELECT timestamp FROM commits WHERE hash = a.hash) DESC
+ORDER BY (SELECT timestamp FROM commits WHERE repo_id = p_repo_id AND hash = a.hash) DESC
 LIMIT 1;
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION pg_git.can_fast_forward(
+    p_repo_id INTEGER,
     p_source TEXT,
     p_target TEXT
 ) RETURNS BOOLEAN AS $$
 WITH RECURSIVE ancestor_chain AS (
     SELECT hash, parent_hash
     FROM commits
-    WHERE hash = p_target
+    WHERE repo_id = p_repo_id AND hash = p_target
     UNION ALL
     SELECT c.hash, c.parent_hash
     FROM commits c
-    JOIN ancestor_chain ac ON ac.parent_hash = c.hash
+    JOIN ancestor_chain ac ON ac.parent_hash = c.hash AND c.repo_id = p_repo_id
 )
 SELECT EXISTS (
     SELECT 1 FROM ancestor_chain WHERE hash = p_source
@@ -75,7 +77,7 @@ BEGIN
     FROM refs WHERE repo_id = p_repo_id AND name = p_target_branch;
     
     -- Check if fast-forward is possible
-    IF pg_git.can_fast_forward(v_source_commit, v_target_commit) THEN
+    IF pg_git.can_fast_forward(p_repo_id, v_source_commit, v_target_commit) THEN
         -- Fast-forward merge
         UPDATE refs
         SET commit_hash = v_source_commit

--- a/sql/functions/013-merge-conflicts.sql
+++ b/sql/functions/013-merge-conflicts.sql
@@ -25,7 +25,7 @@ DECLARE
     v_base_commit TEXT;
 BEGIN
     -- Find merge base
-    v_base_commit := pg_git.find_merge_base(p_our_commit, p_their_commit);
+    v_base_commit := pg_git.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
     
     RETURN QUERY
     WITH our_files AS (

--- a/sql/pgit-plumbing.sql
+++ b/sql/pgit-plumbing.sql
@@ -113,11 +113,12 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION pg_git.merge_base(
+    p_repo_id INTEGER,
     p_commit1 TEXT,
     p_commit2 TEXT
 ) RETURNS TEXT AS $$
     -- Reuse existing merge base finding function
-    SELECT pg_git.find_merge_base(p_commit1, p_commit2);
+    SELECT pg_git.find_merge_base(p_repo_id, p_commit1, p_commit2);
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION pg_git.rev_list(


### PR DESCRIPTION
### Motivation
- Ensure merge-base and fast-forward checks only traverse commits within a single repository to prevent cross-repo ancestry leaks.
- Make merge helper signatures explicitly accept a repository context so callers can forward the current `repo_id`.
- Keep existing higher-level APIs consistent by updating wrapper callers to the new signatures.

### Description
- Change `pg_git.find_merge_base` signature to `p_repo_id INTEGER, p_commit1 TEXT, p_commit2 TEXT` and add `repo_id = p_repo_id` predicates to both seed and recursive `commits` branches plus the timestamp ordering subquery.
- Change `pg_git.can_fast_forward` signature to `p_repo_id INTEGER, p_source TEXT, p_target TEXT` and add `repo_id = p_repo_id` filtering to the initial seed and recursive join of the `ancestor_chain` CTE.
- Update `pg_git.merge_branches` to pass `p_repo_id` into `pg_git.can_fast_forward` and keep ref updates scoped by `repo_id`.
- Update all callers to match the new signatures by changing the `pg_git.merge_base` wrapper in `sql/pgit-plumbing.sql` and the call site in `sql/functions/013-merge-conflicts.sql` to forward `p_repo_id`.

### Testing
- Ran a repository-wide search with `rg -n "find_merge_base\(|can_fast_forward\(" sql` to locate and verify all call sites, which succeeded.
- Inspected the changes with `git diff -- sql/functions/007-merge.sql sql/pgit-plumbing.sql sql/functions/013-merge-conflicts.sql`, which succeeded.
- Verified working tree state with `git status --short` and committed the changes with `git commit -m "Scope merge ancestry helpers by repo_id"`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc4fd02c8832887f6773428b67ab4)