### PR TITLE
Materialize remote-tracking refs on fetch and validate in pull

### DIFF
--- a/sql/functions/011-remote.sql
+++ b/sql/functions/011-remote.sql
@@ -19,6 +19,9 @@ CREATE TABLE pg_git.remote_refs (
     FOREIGN KEY (repo_id, remote_name) REFERENCES pg_git.remotes(repo_id, name)
 );
 
+COMMENT ON TABLE pg_git.remote_refs IS
+    'Source of truth for fetched remote branch tips. fetch_remote materializes these into refs as <remote>/<branch> tracking refs.';
+
 CREATE OR REPLACE FUNCTION pg_git.add_remote(
     p_repo_id INTEGER,
     p_name TEXT,
@@ -46,12 +49,42 @@ BEGIN
     FROM pg_git.remotes
     WHERE repo_id = p_repo_id AND name = p_remote_name;
 
-    -- In a real implementation, this would:
-    -- 1. Connect to remote database using v_remote_url
-    -- 2. Fetch new objects (blobs, trees, commits)
-    -- 3. Update remote refs
-    -- For now, just return empty result
-    RETURN QUERY SELECT NULL::TEXT, NULL::TEXT, NULL::TEXT WHERE FALSE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Remote % does not exist for repo %', p_remote_name, p_repo_id;
+    END IF;
+
+    -- Source of truth: pg_git.remote_refs stores fetched remote branch tips.
+    -- Materialized remote-tracking refs in refs are derived as <remote>/<branch>.
+    RETURN QUERY
+    WITH tracking AS (
+        SELECT
+            rr.ref_name,
+            (p_remote_name || '/' || rr.ref_name) AS tracking_ref,
+            rr.commit_hash AS remote_hash
+        FROM pg_git.remote_refs rr
+        WHERE rr.repo_id = p_repo_id
+          AND rr.remote_name = p_remote_name
+    ),
+    existing AS (
+        SELECT name, commit_hash
+        FROM refs
+        WHERE repo_id = p_repo_id
+    ),
+    upserted AS (
+        INSERT INTO refs (repo_id, name, commit_hash)
+        SELECT p_repo_id, tracking_ref, remote_hash
+        FROM tracking
+        ON CONFLICT (repo_id, name)
+        DO UPDATE SET commit_hash = EXCLUDED.commit_hash
+        RETURNING name, commit_hash
+    )
+    SELECT
+        t.ref_name,
+        e.commit_hash AS old_hash,
+        u.commit_hash AS new_hash
+    FROM upserted u
+    JOIN tracking t ON t.tracking_ref = u.name
+    LEFT JOIN existing e ON e.name = t.tracking_ref;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -86,14 +119,27 @@ CREATE OR REPLACE FUNCTION pg_git.pull(
     p_remote_name TEXT,
     p_ref_name TEXT
 ) RETURNS TEXT AS $$
+DECLARE
+    v_tracking_ref TEXT;
 BEGIN
     -- Fetch from remote
     PERFORM pg_git.fetch_remote(p_repo_id, p_remote_name);
-    
-    -- Merge remote ref into local
+
+    v_tracking_ref := p_remote_name || '/' || p_ref_name;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM refs
+        WHERE repo_id = p_repo_id
+          AND name = v_tracking_ref
+    ) THEN
+        RAISE EXCEPTION 'Remote-tracking ref % does not exist for repo %', v_tracking_ref, p_repo_id;
+    END IF;
+
+    -- Merge verified remote-tracking ref into local branch
     RETURN pg_git.merge_branches(
         p_repo_id,
-        p_remote_name || '/' || p_ref_name,
+        v_tracking_ref,
         p_ref_name
     );
 END;

--- a/test/sql/remote_test.sql
+++ b/test/sql/remote_test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(10);
 
 -- Setup test repository
 SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
@@ -20,17 +20,25 @@ SELECT results_eq(
     'Remote URL stored correctly'
 );
 
+-- Prepare a remote branch tip that fetch materializes into refs as origin/master
+SELECT lives_ok(
+    $$INSERT INTO pg_git.remote_refs (repo_id, remote_name, ref_name, commit_hash)
+      SELECT :repo_id, 'origin', 'master', commit_hash
+      FROM refs
+      WHERE repo_id = :repo_id AND name = 'master'$$,
+    'Can track remote refs'
+);
+
 -- Test fetch operation
 SELECT lives_ok(
     $$SELECT * FROM pg_git.fetch_remote(:repo_id, 'origin')$$,
     'Can fetch from remote'
 );
 
--- Test remote refs
-SELECT lives_ok(
-    $$INSERT INTO pg_git.remote_refs (repo_id, remote_name, ref_name, commit_hash)
-    VALUES (:repo_id, 'origin', 'main', 'test_hash')$$,
-    'Can track remote refs'
+SELECT results_eq(
+    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'origin/master'$$,
+    $$SELECT commit_hash FROM pg_git.remote_refs WHERE repo_id = :repo_id AND remote_name = 'origin' AND ref_name = 'master'$$,
+    'Fetch materializes remote tracking ref in refs'
 );
 
 -- Test push operation
@@ -39,10 +47,17 @@ SELECT lives_ok(
     'Can push to remote'
 );
 
--- Test pull operation
+-- Test pull operation succeeds when tracking branch exists
 SELECT lives_ok(
     $$SELECT pg_git.pull(:repo_id, 'origin', 'master')$$,
-    'Can pull from remote'
+    'Can pull from remote tracked branch'
+);
+
+-- Test pull operation fails with clear error when branch is missing remotely
+SELECT throws_ok(
+    $$SELECT pg_git.pull(:repo_id, 'origin', 'feature')$$,
+    'Remote-tracking ref origin/feature does not exist for repo .*',
+    'Pull fails when remote tracking branch is missing'
 );
 
 -- Test clone operation


### PR DESCRIPTION
### Motivation
- Ensure fetched remote branch tips are materialized as local remote-tracking refs so remote operations can reference them deterministically.
- Make `pg_git.remote_refs` the source of truth for fetched remote tips and keep `refs` as a derived, materialized mapping using `<remote>/<branch>` names.
- Prevent confusing merges by validating the computed remote-tracking ref exists before performing a `pull`/merge and surface a clear error when missing.

### Description
- Added a comment to `pg_git.remote_refs` documenting that it is the authoritative store for fetched remote branch tips and that `refs` holds derived tracking refs named `<remote>/<branch>`.
- Reworked `pg_git.fetch_remote` to validate the remote exists and upsert rows from `pg_git.remote_refs` into `refs` as tracking refs (using `INSERT ... ON CONFLICT DO UPDATE`) and return `(ref_name, old_hash, new_hash)` for affected tracking refs.
- Updated `pg_git.pull` to call `pg_git.fetch_remote`, compute `v_tracking_ref := p_remote_name || '/' || p_ref_name`, verify that the tracking ref exists in `refs`, raise a clear exception when it does not, and then call `pg_git.merge_branches` with the verified tracking ref.
- Added/expanded SQL tests in `test/sql/remote_test.sql` to seed a `remote_refs` row, assert that `fetch_remote` materializes `origin/master` into `refs`, verify a successful pull from a tracked branch, and verify a clear failure when pulling a missing remote branch.

### Testing
- Added `test/sql/remote_test.sql` with assertions for fetch materialization, successful pull from a tracked branch, and failure behavior for a missing remote branch.
- Attempted to run the tests with `pg_prove test/sql/remote_test.sql`, but the `pg_prove` tool is not available in the execution environment so automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc4fdeed08328ba7ebacdfb0f0fa7)