### PR TITLE
Update PGXN meta.json maintainer/contact and release metadata

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -4,7 +4,7 @@
     "description": "A PostgreSQL extension implementing Git-like version control functionality using native database features",
     "version": "0.4.0",
     "maintainer": [
-        "pg_git maintainers <your.email@example.com>"
+        "Sean Evans <sean.w.evans@gmail.com>"
     ],
     "license": "postgresql",
     "provides": {
@@ -33,16 +33,16 @@
             "type": "git"
         }
     },
-    "generated_by": "pg_git maintainers",
+    "generated_by": "Sean Evans",
     "meta-spec": {
         "version": "1.0.0",
         "url": "https://pgxn.org/meta/spec.txt"
     },
     "tags": [
+        "postgresql",
+        "extension",
         "git",
-        "version control",
         "vcs",
-        "repository"
+        "version-control"
     ]
 }
-


### PR DESCRIPTION
### Motivation
- Replace the placeholder maintainer/contact and normalize release metadata so the PGXN package metadata is accurate and passes baseline PGXN metadata checks before release.

### Description
- Replace `maintainer` with `Sean Evans <sean.w.evans@gmail.com>`, update `generated_by` to `Sean Evans`, and normalize `tags` to `["postgresql","extension","git","vcs","version-control"]` while keeping repository URLs and `meta-spec.version` unchanged.

### Testing
- Ran `jq . meta.json` and a Python validation script that checks required fields, maintainer format, repository URL/type, `meta-spec.version`, and `provides.pg_git`, and all automated checks passed; changes were staged and committed with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc7e88bc08328b8359b7da646c008)