### PR TITLE
Register missing test/sql/diff_test.sql in makefile TESTS

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,11 +9,13 @@ DATA = sql/$(EXTENSION)--$(EXTVERSION).sql \
        $(wildcard sql/schema/*.sql) \
        $(wildcard sql/functions/*.sql)
 
+# Register new SQL tests here in execution order (add matching test/sql/*.sql files to this list).
 TESTS := \
        test/sql/init.sql \
        test/sql/add_test.sql \
        test/sql/branch_test.sql \
        test/sql/commit_test.sql \
+       test/sql/diff_test.sql \
        test/sql/merge_test.sql \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
@@ -33,4 +35,3 @@ include $(PGXS)
 .PHONY: test
 test:
 	pg_prove -d postgres $(TESTS)
-


### PR DESCRIPTION
### Motivation
- Ensure every `test/sql/*.sql` file is explicitly registered and preserve a deterministic, intentional execution order for regression tests.

### Description
- Add `test/sql/diff_test.sql` to the `TESTS` list in `makefile` and insert a short comment above `TESTS` explaining that new SQL tests must be added to this list in execution order.

### Testing
- Compared `TESTS` against actual files using `rg`/`sed` to identify the missing file and then committed the update with `git commit`; the checks and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc7e5f76c8328958ea6470ecbbc94)