### PR TITLE
Use manifest-driven SQL test ordering and manifest coverage guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,10 @@ Before cutting a release, complete all of the following:
 
 When adding or changing functionality, ensure tests are updated:
 
-1. **Add a new test file to `test/sql/`** and include it in the `TESTS` list in `makefile`.
-2. **Follow naming conventions** for test files: use lowercase snake case and the `_test.sql` suffix (for example, `new_feature_test.sql`).
-3. **Validate expected target behavior** with assertions that cover:
+1. **Add a new test file to `test/sql/`** using lowercase snake case and the `_test.sql` suffix (for example, `new_feature_test.sql`).
+2. **Add the new test path to `test/sql/manifest.txt`** in the correct execution position. This manifest is the authoritative test order for `make test`.
+3. **Run `make check-test-manifest`** to confirm all `test/sql/*_test.sql` files are listed in the manifest.
+4. **Validate expected target behavior** with assertions that cover:
    - normal/success paths,
    - relevant edge cases,
    - error handling where applicable.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ CREATE EXTENSION pg_git;
 
 ## Testing
 
+The authoritative test execution order is defined in `test/sql/manifest.txt`.
+`make test` reads that manifest, runs tests in the listed order, and enforces a guard
+that every `test/sql/*_test.sql` file is present in the manifest.
+
 ```bash
+# Optional overrides for your local PostgreSQL connection used by pg_prove:
+# PGHOST=localhost PGPORT=5432 PGUSER=postgres PGDATABASE=postgres
 make test
 ```
 

--- a/makefile
+++ b/makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 EXTENSION = pg_git
 EXTVERSION = 0.4.0
 
@@ -14,22 +16,9 @@ DATA = \
        $(wildcard sql/schema/*.sql) \
        $(wildcard sql/functions/*.sql)
 
-# Register new SQL tests here in execution order (add matching test/sql/*.sql files to this list).
-TESTS := \
-       test/sql/init.sql \
-       test/sql/add_test.sql \
-       test/sql/branch_test.sql \
-       test/sql/commit_test.sql \
-       test/sql/diff_test.sql \
-       test/sql/merge_test.sql \
-       test/sql/remote_test.sql \
-       test/sql/advanced_test.sql \
-       test/sql/gc_test.sql \
-       test/sql/https_fetch_test.sql \
-       test/sql/optimize_indexes_test.sql \
-       test/sql/gc_performance_test.sql
-
-
+# Authoritative test order lives in test/sql/manifest.txt.
+TEST_MANIFEST := test/sql/manifest.txt
+TESTS := $(shell sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$$/d' $(TEST_MANIFEST))
 
 # Derive the target names from the TESTS list to keep them in sync.
 REGRESS := $(notdir $(basename $(TESTS)))
@@ -37,6 +26,16 @@ REGRESS_OPTS = --inputdir=test
 
 include $(PGXS)
 
-.PHONY: test
-test:
+.PHONY: test check-test-manifest
+test: check-test-manifest
 	pg_prove -d postgres $(TESTS)
+
+check-test-manifest:
+	@missing=$$(comm -23 \
+		<(find test/sql -maxdepth 1 -type f -name '*_test.sql' | sort) \
+		<(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$$/d' $(TEST_MANIFEST) | sort)); \
+	if [ -n "$$missing" ]; then \
+		echo "ERROR: test files missing from $(TEST_MANIFEST):"; \
+		echo "$$missing"; \
+		exit 1; \
+	fi

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -1,0 +1,16 @@
+# Ordered pg_prove test manifest.
+# Keep one path per line. Execution order is authoritative.
+# Include bootstrap scripts (e.g., init.sql) before *_test.sql files.
+test/sql/init.sql
+test/sql/add_test.sql
+test/sql/branch_test.sql
+test/sql/commit_test.sql
+test/sql/diff_test.sql
+test/sql/merge_test.sql
+test/sql/remote_test.sql
+test/sql/advanced_test.sql
+test/sql/search_path_qualification_test.sql
+test/sql/gc_test.sql
+test/sql/https_fetch_test.sql
+test/sql/optimize_indexes_test.sql
+test/sql/gc_performance_test.sql


### PR DESCRIPTION
### Motivation

- Replace the fragile, hand-maintained `TESTS := ...` list in `makefile` with a single authoritative source of truth so test order is deterministic and easier to update. 
- Ensure contributors cannot accidentally add `test/sql/*_test.sql` files without registering them in the execution order. 

### Description

- Add `test/sql/manifest.txt` as the authoritative, ordered list of tests and include bootstrap entries like `test/sql/init.sql`. 
- Change `makefile` to read `TESTS` from `TEST_MANIFEST := test/sql/manifest.txt` using `sed` and preserve ordered execution by feeding that list to `pg_prove`. 
- Add a `check-test-manifest` make target that fails when any discovered `test/sql/*_test.sql` file is missing from the manifest, using a `comm`/`find`/`sed` check, and make `test` depend on this guard. 
- Update `README.md` Testing section to document the manifest-driven mechanism and `make test` invocation, and update `CONTRIBUTING.md` with guidance to add new tests by adding the file and registering its path in `test/sql/manifest.txt` and running `make check-test-manifest`.

### Testing

- Attempted `make check-test-manifest` and `make -n test` but the local environment lacks the PGXS include path (error: `/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk`) so the Makefile-based run could not complete. 
- Validated the coverage guard logic externally with the shell check `comm -23 <(find test/sql -maxdepth 1 -type f -name '*_test.sql' | sort) <(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$$/d' test/sql/manifest.txt | sort)`, which initially reported one missing entry. 
- Added the missing `test/sql/search_path_qualification_test.sql` to `test/sql/manifest.txt` and re-ran the same `comm`/`find`/`sed` validation, which returned no missing files (guard logic passes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcfcc04a88328a5200ebbecaba453)