### PR TITLE
Add SQL test triage guide and focused test rerun make targets

### DIFF
--- a/docs/test-triage.md
+++ b/docs/test-triage.md
@@ -1,0 +1,76 @@
+# Test Triage Guide
+
+This guide defines a consistent workflow for diagnosing and fixing SQL test failures.
+
+## 1) Capture the first failing test
+
+1. Run the full suite and stop at first failure in your notes:
+
+   ```bash
+   make test
+   ```
+
+2. Record the first failure only (file + failing assertion + error text). Triage starts from the earliest failure to avoid chasing follow-on noise.
+3. Save the exact command output snippet in the issue/PR notes so others can reproduce quickly.
+
+## 2) Rerun one SQL test file
+
+Use focused reruns before changing more than one area:
+
+```bash
+make test-one TEST=test/sql/merge_test.sql
+```
+
+For repeated local debugging, use:
+
+```bash
+make test-one-verbose TEST=test/sql/merge_test.sql
+```
+
+This keeps the failure loop short while preserving the same test harness.
+
+## 3) Classify failure type before fixing
+
+Every failure should be assigned one primary type:
+
+- **Logic bug**: SQL/function behavior is incorrect relative to expected assertions.
+- **Migration drift**: schema or upgrade path mismatch between expected and installed DB objects.
+- **Env/setup**: missing dependency, bad config, service availability, permissions, or test harness setup issue.
+- **Nondeterminism**: ordering, timing, randomization, or external-state dependency causing flaky behavior.
+
+If a failure appears multi-causal, mark the dominant root cause first and list secondary factors.
+
+## 4) Required artifacts for each failing test
+
+Each failure tracked in an issue or PR must include:
+
+1. **Root-cause note**: short explanation of why it failed (not only symptoms).
+2. **Fix commit**: commit hash that resolves the issue.
+3. **Regression assertion**: a new or tightened assertion in the same SQL test file, or an adjacent test file when shared setup is required.
+
+No failure is considered closed without all three artifacts.
+
+## 5) Post-fix checklist (cross-test isolation)
+
+After implementing a fix, verify no accidental cross-test state leakage:
+
+- [ ] Any objects created by the test are cleaned up (tables, schemas, temp artifacts, roles where applicable).
+- [ ] Test setup does not assume prior test side effects.
+- [ ] Schema/search path expectations are explicitly reset when modified.
+- [ ] Sequences/counters or mutable globals used by assertions are reset or namespaced.
+- [ ] Focused rerun (`make test-one`) passes.
+- [ ] Full suite (`make test`) passes after focused fix validation.
+
+## 6) Known failures (temporary tracking)
+
+Track recurring signatures here until fully resolved (remove entries once fixed and stable):
+
+| Signature / error text | Likely class | Current status | Owner | Linked issue |
+| --- | --- | --- | --- | --- |
+| _Example: duplicate key value violates unique constraint on merge temp table_ | Nondeterminism | Investigating | @owner | #123 |
+
+Rules:
+
+- Keep signature text short and copy-pastable from failure output.
+- Update status on every recurrence or mitigation attempt.
+- Delete entry only after the fix is merged and no recurrence is observed in subsequent runs.

--- a/makefile
+++ b/makefile
@@ -37,6 +37,27 @@ REGRESS_OPTS = --inputdir=test
 
 include $(PGXS)
 
-.PHONY: test
+
+.PHONY: test test-one test-one-verbose test-list
 test:
 	pg_prove -d postgres $(TESTS)
+
+# Focused rerun for a single SQL test file: make test-one TEST=test/sql/merge_test.sql
+test-one:
+	@if [ -z "$(TEST)" ]; then \
+		echo "Usage: make test-one TEST=test/sql/<file>.sql"; \
+		exit 1; \
+	fi
+	pg_prove -d postgres $(TEST)
+
+# Verbose focused rerun for richer diagnostics
+test-one-verbose:
+	@if [ -z "$(TEST)" ]; then \
+		echo "Usage: make test-one-verbose TEST=test/sql/<file>.sql"; \
+		exit 1; \
+	fi
+	pg_prove -v -d postgres $(TEST)
+
+# Print registered SQL test files in execution order
+test-list:
+	@printf "%s\n" $(TESTS)


### PR DESCRIPTION
### Motivation

- Provide a documented, repeatable workflow for capturing and triaging the first failing SQL test to reduce noise and speed root-cause analysis.
- Make it easy to run a single SQL test file or print the ordered test list to shorten the local debug loop and avoid full-suite runs during investigation.
- Enforce per-failure artifacts (root-cause note, fix commit, regression assertion) and a post-fix checklist to prevent cross-test state leakage and track recurring failure signatures until resolved.

### Description

- Added `docs/test-triage.md` with sections for capturing the first failing test, how to rerun a single SQL test file, failure classification (logic bug, migration drift, env/setup, nondeterminism), required artifacts per failure, a post-fix isolation checklist, and a small known-failures tracking table.
- Updated `makefile` to add focused test helpers: `test-one` (run one SQL test via `TEST=...`), `test-one-verbose` (verbose single-file run), and `test-list` (print the ordered `TESTS` list), and expanded `.PHONY` accordingly while preserving the existing `test` target.
- Fixed a makefile formatting/continuation issue encountered while inserting the new targets so the `test-list` recipe prints `$(TESTS)` correctly when invoked.

### Testing

- Validated makefile formatting iteratively (fixed an initial missing-separator/tab issue), and confirmed the `test-list` recipe is present and prints the `TESTS` list when the environment provides PGXS.
- Ran `make test-list` in the current environment which failed because the host is missing the PostgreSQL PGXS include (`/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk`), so full `make` invocation could not be executed here.
- No automated SQL test-suite runs were performed in this environment because the required PostgreSQL build infrastructure was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcfce4f148328a3c4acf7bd78cab6)