### PR TITLE
Split SQL tests into core, integration, and performance suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 0"
 
 jobs:
-  test:
+  test-core:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,6 +18,19 @@ jobs:
         run: |
           make
           sudo make install
-      - name: Run tests
+      - name: Run core tests
         run: |
           docker compose up --abort-on-container-exit --exit-code-from test test
+
+  test-slow-suites:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build and install extension
+        run: |
+          make
+          sudo make install
+      - name: Run integration and performance suites
+        run: |
+          docker compose run --rm -e RUN_INTEGRATION=1 -e RUN_PERF=1 test make test-all

--- a/README.md
+++ b/README.md
@@ -111,8 +111,25 @@ CREATE EXTENSION pg_git;
 
 ## Testing
 
+Test suites are split by speed and external dependencies:
+
+- `test-core` (default): deterministic SQL tests for local logic. **Expected runtime:** ~10-30 seconds in Docker on a modern laptop. **Prerequisites:** running PostgreSQL test database.
+- `test-integration` (opt-in): HTTPS transport checks in `test/sql/https_fetch_test.sql`. **Expected runtime:** ~30-90 seconds depending on network/container startup. **Prerequisites:** set `RUN_INTEGRATION=1`; `plpython3u` available; outbound HTTPS/network available.
+- `test-performance` (opt-in): GC performance regression checks in `test/sql/gc_performance_test.sql`. **Expected runtime:** ~1-5+ minutes depending on machine load. **Prerequisites:** set `RUN_PERF=1`; stable CPU/IO for consistent measurements.
+- `test-all`: runs `test-core` and then conditionally runs integration/performance suites when their flags are enabled.
+
 ```bash
-make test
+# Fast default suite (also what `make test` runs)
+make test-core
+
+# Explicitly include HTTPS/integration tests
+RUN_INTEGRATION=1 make test-integration
+
+# Explicitly include performance tests
+RUN_PERF=1 make test-performance
+
+# Run everything (slow suites run only when flags are set)
+RUN_INTEGRATION=1 RUN_PERF=1 make test-all
 ```
 
 ## Development

--- a/makefile
+++ b/makefile
@@ -14,8 +14,8 @@ DATA = \
        $(wildcard sql/schema/*.sql) \
        $(wildcard sql/functions/*.sql)
 
-# Register new SQL tests here in execution order (add matching test/sql/*.sql files to this list).
-TESTS := \
+# Deterministic, fast SQL tests that run on every change.
+CORE_TESTS := \
        test/sql/init.sql \
        test/sql/add_test.sql \
        test/sql/branch_test.sql \
@@ -25,11 +25,17 @@ TESTS := \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
        test/sql/gc_test.sql \
-       test/sql/https_fetch_test.sql \
-       test/sql/optimize_indexes_test.sql \
+       test/sql/optimize_indexes_test.sql
+
+# Slower/less deterministic suites are opt-in.
+INTEGRATION_TESTS := \
+       test/sql/https_fetch_test.sql
+
+PERFORMANCE_TESTS := \
        test/sql/gc_performance_test.sql
 
-
+# Backward-compatible aggregate for PGXS regress helpers.
+TESTS := $(CORE_TESTS) $(INTEGRATION_TESTS) $(PERFORMANCE_TESTS)
 
 # Derive the target names from the TESTS list to keep them in sync.
 REGRESS := $(notdir $(basename $(TESTS)))
@@ -37,6 +43,26 @@ REGRESS_OPTS = --inputdir=test
 
 include $(PGXS)
 
-.PHONY: test
-test:
-	pg_prove -d postgres $(TESTS)
+.PHONY: test test-core test-integration test-performance test-all
+
+# Keep `make test` as fast default.
+test: test-core
+
+test-core:
+	pg_prove -d postgres $(CORE_TESTS)
+
+test-integration:
+	@if [ "$(RUN_INTEGRATION)" != "1" ]; then \
+		echo "Skipping integration tests. Set RUN_INTEGRATION=1 to run them."; \
+		exit 0; \
+	fi
+	pg_prove -d postgres $(INTEGRATION_TESTS)
+
+test-performance:
+	@if [ "$(RUN_PERF)" != "1" ]; then \
+		echo "Skipping performance tests. Set RUN_PERF=1 to run them."; \
+		exit 0; \
+	fi
+	pg_prove -d postgres $(PERFORMANCE_TESTS)
+
+test-all: test-core test-integration test-performance


### PR DESCRIPTION
### Motivation

- Reduce feedback time by keeping deterministic, fast SQL tests as the default suite (`test-core`).
- Move slower or non-deterministic checks (HTTPS transport and GC perf) to opt-in suites so they do not slow normal development.
- Make running slower suites explicit via environment flags to avoid accidental runs (`RUN_INTEGRATION`, `RUN_PERF`).
- Ensure CI runs fast core tests on every change and runs slower suites on a scheduled or manual cadence.

### Description

- Reworked the `makefile` to introduce `CORE_TESTS`, `INTEGRATION_TESTS`, and `PERFORMANCE_TESTS`, and kept a backward-compatible `TESTS` aggregate.
- Added Make targets `test-core`, `test-integration`, `test-performance`, and `test-all`, and made the default `test` target an alias for `test-core`.
- Gated slow suites so `test-integration` requires `RUN_INTEGRATION=1` and `test-performance` requires `RUN_PERF=1`, and each target prints a skip message when the flag is not set.
- Updated `.github/workflows/ci.yml` to run `test-core` on push/pull_request and to run integration/performance suites only on schedule or manual dispatch, and expanded `README.md` with suite descriptions, expected runtimes, prerequisites, and example commands (e.g. `make test-core`, `RUN_INTEGRATION=1 make test-integration`).

### Testing

- Attempted to validate the new targets locally with `make test-integration && make test-performance && make -n test-core` to ensure the gating and default alias behave as intended.
- The local run could not complete because PGXS is not available in this environment (`/usr/lib/postgresql/.../pgxs.mk: No such file or directory`), so the automated test commands did not execute here.
- CI is configured to run `test-core` on push/PR and will run slow suites on schedule or when manually dispatched, where those jobs will exercise the opt-in behavior and environment flags.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcfce6e108328b9fc56a2f3127930)