### PR TITLE
Fix test target coverage and add single-test runners

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,6 +35,7 @@ CORE_TESTS := \
        test/sql/merge_test.sql \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
+       test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \
        test/sql/optimize_indexes_test.sql
 
@@ -54,7 +55,7 @@ REGRESS_OPTS = --inputdir=test
 
 include $(PGXS)
 
-.PHONY: test test-core test-integration test-performance test-all
+.PHONY: test test-core test-integration test-performance test-all test-one test-one-verbose
 
 # Keep `make test` as fast default.
 test: test-core
@@ -77,3 +78,20 @@ test-performance:
 	pg_prove -d postgres $(PERFORMANCE_TESTS)
 
 test-all: test-core test-integration test-performance
+
+
+# Run a single SQL test file (e.g., make test-one TEST=test/sql/merge_test.sql).
+test-one:
+	@if [ -z "$(TEST)" ]; then \
+		echo "Usage: make test-one TEST=test/sql/<name>.sql"; \
+		exit 2; \
+	fi
+	pg_prove -d postgres $(TEST)
+
+# Verbose single-test execution for local triage/debugging.
+test-one-verbose:
+	@if [ -z "$(TEST)" ]; then \
+		echo "Usage: make test-one-verbose TEST=test/sql/<name>.sql"; \
+		exit 2; \
+	fi
+	pg_prove --verbose -d postgres $(TEST)


### PR DESCRIPTION
### Motivation
- `test/sql/search_path_qualification_test.sql` was present in the manifest but not included in the default core test list, causing inconsistent default coverage.
- The test-triage documentation documents focused single-test targets but the `Makefile` lacked `test-one`/`test-one-verbose`, making local triage harder.

### Description
- Added `test/sql/search_path_qualification_test.sql` to the `CORE_TESTS` list so it runs as part of the default `make test` flow.
- Added `test-one` and `test-one-verbose` Make targets that run a single SQL test file using `pg_prove` and include usage guards when `TEST` is unset.
- Updated `.PHONY` to include the new targets and placed the new targets in the `Makefile` after the existing `test-all` target.

### Testing
- Ran `pytest -q`, which reported that no pytest tests exist in this repository (no tests ran).
- Attempted `make test`, which could not run the SQL test harness in this environment due to a missing PGXS include file at `/usr/lib/postgresql/16/lib/pgxs/src/makefiles/pgxs.mk`, so `pg_prove`-based tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd659abd883289c17aa189cbd312d)