### PR TITLE
Handle missing PGXS gracefully when running tests

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ EXTVERSION = 0.4.0
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
+HAVE_PGXS := $(if $(wildcard $(PGXS)),1,0)
 
 # PostgreSQL connection defaults for local development/testing.
 PGDATABASE ?= postgres
@@ -53,7 +54,11 @@ TESTS := $(CORE_TESTS) $(INTEGRATION_TESTS) $(PERFORMANCE_TESTS)
 REGRESS := $(notdir $(basename $(TESTS)))
 REGRESS_OPTS = --inputdir=test
 
+ifeq ($(HAVE_PGXS),1)
 include $(PGXS)
+else
+$(warning PGXS makefile not found at $(PGXS); build/install targets are unavailable in this environment.)
+endif
 
 .PHONY: test test-core test-integration test-performance test-all test-one test-one-verbose
 


### PR DESCRIPTION
### Motivation
- Avoid hard make failures when `pg_config --pgxs` points to a non-existent `pgxs.mk` so test targets and other non-build flows can still be evaluated.

### Description
- Add `HAVE_PGXS := $(if $(wildcard $(PGXS)),1,0)` and conditionally `include $(PGXS)` with a clear warning in `makefile` when PGXS is missing, allowing `make` to continue.

### Testing
- Ran `make test-core`, which now emits the PGXS warning and proceeds to invoke `pg_prove` but the run failed because `pg_prove` is not installed (Error 127).
- Ran `pytest -q` earlier which reported "no tests ran" since there are no Python tests in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd9be0ae48328bcda16f3e4b0b49c)