### PR TITLE
Fix extension install and get the pgTAP test suite passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ A PostgreSQL-native Git implementation.
 The `pg_git.control` file provides PostgreSQL with metadata about the
 extension and instructs it to load `sql/pg_git--0.4.0.sql` when the
 extension is created. Both the control file and the SQL script are
-installed by `make install`.
+installed by `make install`. The install script is generated from the
+modular fragments under `sql/schema/`, `sql/functions/` and `sql/pgit-*.sql`
+(run `make` to regenerate it); editing it by hand is not recommended.
+
+> **Schema name:** the extension installs its objects into the `pggit`
+> schema (e.g. `pggit.init_repository(...)`). PostgreSQL reserves the
+> `pg_` prefix for system schemas, so the schema cannot be named `pg_git`
+> even though the extension itself is called `pg_git`.
 
 ## Dependencies
 
@@ -93,20 +100,18 @@ installed by `make install`.
 ### Optional (feature usage)
 - None currently. All listed dependencies are required to install `pg_git` as shipped.
 
-> **Why `plpython3u` is required:** the extension defines HTTPS helper functions (for example `pg_git.http_fetch`) in `LANGUAGE plpython3u`. That means `plpython3u` must be present when `CREATE EXTENSION pg_git` runs. In practice, only HTTPS-related features use those functions directly.
+> **Why `plpython3u` is required:** the extension defines HTTPS helper functions (for example `pggit.http_fetch`) in `LANGUAGE plpython3u`. That means `plpython3u` must be present when `CREATE EXTENSION pg_git` runs. In practice, only HTTPS-related features use those functions directly.
 
 ## Installation
 ```bash
 make && make install
 
-# In PostgreSQL:
-CREATE EXTENSION plpython3u;
-CREATE EXTENSION pgcrypto;
-CREATE EXTENSION pg_trgm;
-CREATE EXTENSION pg_git;
+# In PostgreSQL: CASCADE auto-installs the required extensions
+# (pgcrypto, pg_trgm, plpython3u).
+CREATE EXTENSION pg_git CASCADE;
 
 # Alternatively, from the command line:
-# psql -d yourdb -c "CREATE EXTENSION plpython3u; CREATE EXTENSION pgcrypto; CREATE EXTENSION pg_trgm; CREATE EXTENSION pg_git;"
+# psql -d yourdb -c "CREATE EXTENSION pg_git CASCADE;"
 ```
 
 ## Testing
@@ -151,47 +156,47 @@ docker-compose run --rm test
 ```sql
 
 -- Initialize repository
-SELECT pg_git.init_repository('my_repository', '/path/to/repo');
+SELECT pggit.init_repository('my_repository', '/path/to/repo');
 
 -- Clone repository
-SELECT pg_git.clone('https://github.com/org/repo.git', 'local_name', '/path');
+SELECT pggit.clone('https://github.com/org/repo.git', 'local_name', '/path');
 
 -- Stage / unstage files
-SELECT pg_git.stage_file(1, 'file.txt', 'content'::bytea);
-SELECT pg_git.unstage_file(1, 'file.txt');
+SELECT pggit.stage_file(1, 'file.txt', 'content'::bytea);
+SELECT pggit.unstage_file(1, 'file.txt');
 
 -- Commit
-SELECT pg_git.commit_index(1, 'author', 'Your commit message here');
+SELECT pggit.commit_index(1, 'author', 'Your commit message here');
 
 -- Branch creation and checkout
-SELECT pg_git.create_branch(1, 'feature');
-SELECT pg_git.checkout_branch(1, 'feature');
+SELECT pggit.create_branch(1, 'feature');
+SELECT pggit.checkout_branch(1, 'feature');
 
 -- Merge Branch
-SELECT pg_git.merge_branches(1, 'feature', 'main');
+SELECT pggit.merge_branches(1, 'feature', 'main');
 
 -- Remote operations with HTTPS
 -- Set encryption key for storing credentials
-ALTER SYSTEM SET pg_git.credential_key = 'my_secret';
+ALTER SYSTEM SET pggit.credential_key = 'my_secret';
 SELECT pg_reload_conf();
-SELECT pg_git.store_credentials(1, 'github.com', 'username', 'token');
+SELECT pggit.store_credentials(1, 'github.com', 'username', 'token');
 -- `http_fetch` uses Python to perform the actual HTTPS request
 
 -- Garbage collection
-SELECT * FROM pg_git.gc(1);
+SELECT * FROM pggit.gc(1);
 
 -- Integrity verification
-SELECT * FROM pg_git.verify_integrity(1);
+SELECT * FROM pggit.verify_integrity(1);
 
 -- Index optimization
-SELECT * FROM pg_git.optimize_indexes(1);
+SELECT * FROM pggit.optimize_indexes(1);
 
 -- View history
-SELECT * FROM pg_git.get_log(1);
+SELECT * FROM pggit.get_log(1);
 
 -- Tagging
-SELECT pg_git.create_tag(1, 'v1.0.0');
-SELECT * FROM pg_git.list_tags(1);
+SELECT pggit.create_tag(1, 'v1.0.0');
+SELECT * FROM pggit.list_tags(1);
 ```
 
 ## Version

--- a/makefile
+++ b/makefile
@@ -16,18 +16,40 @@ PGUSER ?= postgres
 # Shared psql command for test/preflight checks.
 PSQL := psql -v ON_ERROR_STOP=1 -X -w -h $(PGHOST) -p $(PGPORT) -U $(PGUSER) -d $(PGDATABASE)
 
-# Shared pg_prove command honoring connection defaults/overrides.
-PG_PROVE := PGHOST=$(PGHOST) PGPORT=$(PGPORT) PGUSER=$(PGUSER) PGDATABASE=$(PGDATABASE) pg_prove
+# Shared pg_prove command honoring connection defaults/overrides. The extension
+# installs into the pggit schema; tests reference its objects unqualified, so the
+# session search_path includes pggit (public keeps pgtap and contrib visible).
+# Tests that must prove search_path independence override this with SET LOCAL.
+PG_PROVE := PGHOST=$(PGHOST) PGPORT=$(PGPORT) PGUSER=$(PGUSER) PGDATABASE=$(PGDATABASE) PGOPTIONS='-c search_path=pggit,public' pg_prove
 
-# Installable SQL assets only:
-#   - extension install/upgrade entrypoints in sql/*.sql
-#   - schema/function fragments loaded by those entrypoints
-# Explicitly exclude non-extension artifacts accidentally placed in sql/.
-DATA = \
-       $(sort $(filter-out sql/pgit-ci.sql sql/pgit-control.sql, \
-       $(wildcard sql/*.sql))) \
-       $(wildcard sql/schema/*.sql) \
-       $(wildcard sql/functions/*.sql)
+# Single-file install entrypoint loaded by CREATE EXTENSION. Because the
+# CREATE EXTENSION machinery cannot process psql \i/\ir includes, this script
+# is assembled from the modular SQL fragments below (see the rule near the end
+# of this file). It is a generated artifact: edit the fragments, not this file.
+EXT_SQL = sql/$(EXTENSION)--$(EXTVERSION).sql
+
+# Fragments composing the install script, in load order:
+#   1. schema    - base tables (repositories must precede its referencing tables)
+#   2. functions - callable API, numbered to fix ordering
+#   3. features  - advanced command modules
+# CI/control fragments and version-upgrade scripts are intentionally excluded
+# from a fresh install.
+SCHEMA_PARTS = \
+       sql/schema/001-core.sql \
+       sql/schema/pgit-schema.sql
+FUNCTION_PARTS = $(sort $(wildcard sql/functions/*.sql))
+FEATURE_PARTS = $(sort $(filter-out \
+       sql/pgit-ci.sql \
+       sql/pgit-control.sql \
+       sql/pgit-update.sql \
+       sql/pgit-version.sql \
+       sql/pgit-version-updates.sql \
+       sql/pgit-version-updates-0.2.0--0.3.0.sql, \
+       $(wildcard sql/pgit-*.sql)))
+INSTALL_PARTS = $(SCHEMA_PARTS) $(FUNCTION_PARTS) $(FEATURE_PARTS)
+
+# Only the assembled entrypoint is installed into the extension directory.
+DATA = $(EXT_SQL)
 
 # Deterministic, fast SQL tests that run on every change.
 CORE_TESTS := \
@@ -62,6 +84,23 @@ include $(PGXS)
 else
 $(warning PGXS makefile not found at $(PGXS); build/install targets are unavailable in this environment.)
 endif
+
+# Assemble the single-file install script from the modular fragments. Plain
+# concatenation in dependency order; the fragments contain no psql meta-commands.
+$(EXT_SQL): $(INSTALL_PARTS)
+	@printf '%s\n' \
+	  '-- pg_git $(EXTVERSION)' \
+	  '-- GENERATED FILE -- DO NOT EDIT.' \
+	  '-- Assembled from sql/schema/*.sql, sql/functions/*.sql and sql/pgit-*.sql.' \
+	  '-- Regenerate with: make $(EXT_SQL)' > $@
+	@for f in $(INSTALL_PARTS); do \
+	  printf '\n-- ===== %s =====\n' "$$f" >> $@; \
+	  cat "$$f" >> $@; \
+	done
+	@echo "Generated $@ from $(words $(INSTALL_PARTS)) fragments."
+
+# Ensure the entrypoint is (re)assembled as part of the default build.
+all: $(EXT_SQL)
 
 .PHONY: test test-core test-integration test-performance test-all test-one test-one-verbose check-pg_prove
 

--- a/pg_git.control
+++ b/pg_git.control
@@ -1,6 +1,6 @@
 comment = 'Git implementation in PostgreSQL'
 default_version = '0.4.0'
-schema = pg_git
-relocatable = true
+schema = pggit
+relocatable = false
 requires = 'plpgsql,pgcrypto,pg_trgm,plpython3u'
 

--- a/sql/functions/001-init.sql
+++ b/sql/functions/001-init.sql
@@ -1,21 +1,14 @@
-CREATE TABLE pg_git.repositories (
-    id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL,
-    path TEXT NOT NULL UNIQUE,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-);
-
 CREATE OR REPLACE FUNCTION init_repository(
     p_name TEXT,
     p_path TEXT
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_repo_id INTEGER;
     v_initial_tree TEXT;
     v_initial_commit TEXT;
 BEGIN
     -- Create repository record
-    INSERT INTO pg_git.repositories (name, path)
+    INSERT INTO pggit.repositories (name, path)
     VALUES (p_name, p_path)
     RETURNING id INTO v_repo_id;
     

--- a/sql/functions/002-add.sql
+++ b/sql/functions/002-add.sql
@@ -3,7 +3,7 @@
 
 -- Helper function to normalize file paths and prevent traversal
 CREATE OR REPLACE FUNCTION normalize_path(p_path TEXT)
-RETURNS TEXT AS $$
+RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_parts TEXT[];
     v_stack TEXT[] := ARRAY[]::TEXT[];
@@ -11,7 +11,8 @@ DECLARE
 BEGIN
     -- Reject absolute paths
     IF p_path LIKE '/%' THEN
-        RAISE EXCEPTION 'Absolute paths are not allowed: %', p_path;
+        RAISE EXCEPTION 'Absolute paths are not allowed'
+            USING DETAIL = format('path: %s', p_path);
     END IF;
 
     -- Split and process path components
@@ -22,7 +23,8 @@ BEGIN
         ELSIF v_part = '..' THEN
             -- Prevent traversing above repository root
             IF array_length(v_stack, 1) IS NULL THEN
-                RAISE EXCEPTION 'Path traversal is not allowed: %', p_path;
+                RAISE EXCEPTION 'Path traversal is not allowed'
+                    USING DETAIL = format('path: %s', p_path);
             END IF;
             v_stack := v_stack[1:array_length(v_stack,1)-1];
         ELSE
@@ -40,7 +42,7 @@ CREATE OR REPLACE FUNCTION stage_file(
     p_path TEXT,
     p_content BYTEA,
     p_mode TEXT DEFAULT '100644'
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_blob_hash TEXT;
     v_norm_path TEXT;
@@ -65,7 +67,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION unstage_file(
     p_repo_id INTEGER,
     p_path TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_norm_path TEXT;
 BEGIN

--- a/sql/functions/003-commit.sql
+++ b/sql/functions/003-commit.sql
@@ -1,9 +1,9 @@
 -- Path: /sql/functions/003-commit.sql
 -- pg_git commit functions
 
-CREATE OR REPLACE FUNCTION pg_git.create_tree_from_index(
+CREATE OR REPLACE FUNCTION pggit.create_tree_from_index(
     p_repo_id INTEGER
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_entries JSONB;
 BEGIN
@@ -22,15 +22,15 @@ BEGIN
         ORDER BY path
     ) ordered_entries;
 
-    RETURN pg_git.create_tree(p_repo_id, COALESCE(v_entries, '[]'::jsonb));
+    RETURN pggit.create_tree(p_repo_id, COALESCE(v_entries, '[]'::jsonb));
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.commit_index(
+CREATE OR REPLACE FUNCTION pggit.commit_index(
     p_repo_id INTEGER,
     p_author TEXT,
     p_message TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_tree_hash TEXT;
     v_parent_hash TEXT;
@@ -38,14 +38,14 @@ DECLARE
 BEGIN
     -- Get current HEAD
     SELECT commit_hash INTO v_parent_hash
-    FROM pg_git.refs
+    FROM pggit.refs
     WHERE repo_id = p_repo_id AND name = 'HEAD';
 
     -- Create tree from index
-    v_tree_hash := pg_git.create_tree_from_index(p_repo_id);
+    v_tree_hash := pggit.create_tree_from_index(p_repo_id);
 
     -- Create commit
-    v_commit_hash := pg_git.create_commit(
+    v_commit_hash := pggit.create_commit(
         p_repo_id,
         v_tree_hash,
         v_parent_hash,
@@ -54,8 +54,8 @@ BEGIN
     );
 
     -- Update HEAD and branch reference
-    UPDATE pg_git.refs SET commit_hash = v_commit_hash WHERE repo_id = p_repo_id AND name = 'HEAD';
-    UPDATE pg_git.refs
+    UPDATE pggit.refs SET commit_hash = v_commit_hash WHERE repo_id = p_repo_id AND name = 'HEAD';
+    UPDATE pggit.refs
     SET commit_hash = v_commit_hash
     WHERE repo_id = p_repo_id
       AND commit_hash = v_parent_hash

--- a/sql/functions/004-log.sql
+++ b/sql/functions/004-log.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/004-log.sql
 -- pg_git log functions
 
-CREATE OR REPLACE FUNCTION pg_git.get_log(
+CREATE OR REPLACE FUNCTION pggit.get_log(
     p_repo_id INTEGER,
     p_limit INTEGER DEFAULT NULL
 ) RETURNS TABLE (
@@ -10,42 +10,43 @@ CREATE OR REPLACE FUNCTION pg_git.get_log(
     parent_hash TEXT,
     author TEXT,
     message TEXT,
-    timestamp TIMESTAMP WITH TIME ZONE
-) AS $$
+    "timestamp" TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
 DECLARE
     v_head_commit TEXT;
 BEGIN
     -- Get HEAD commit
     SELECT commit_hash INTO v_head_commit
-    FROM pg_git.refs
+    FROM pggit.refs
     WHERE repo_id = p_repo_id AND name = 'HEAD';
 
     RETURN QUERY
     WITH RECURSIVE commit_log AS (
         SELECT c.*
-        FROM pg_git.commits c
+        FROM pggit.commits c
         WHERE c.repo_id = p_repo_id AND c.hash = v_head_commit
 
         UNION ALL
 
         SELECT c.*
-        FROM pg_git.commits c
+        FROM pggit.commits c
         INNER JOIN commit_log cl ON c.repo_id = p_repo_id AND c.hash = cl.parent_hash
     )
-    SELECT *
+    SELECT commit_log.hash, commit_log.tree_hash, commit_log.parent_hash,
+           commit_log.author, commit_log.message, commit_log."timestamp"
     FROM commit_log
     LIMIT p_limit;
 END;
 $$ LANGUAGE plpgsql;
 
 -- Pretty format version with commit decoration
-CREATE OR REPLACE FUNCTION pg_git.get_decorated_log(
+CREATE OR REPLACE FUNCTION pggit.get_decorated_log(
     p_repo_id INTEGER,
     p_limit INTEGER DEFAULT NULL
 ) RETURNS TABLE (
     commit_line TEXT,
     refs TEXT[]
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     WITH commit_refs AS (
@@ -53,9 +54,9 @@ BEGIN
                c.message,
                c.author,
                c.timestamp,
-               array_agg(r.name) as ref_names
-        FROM pg_git.get_log(p_repo_id, p_limit) c
-        LEFT JOIN pg_git.refs r ON r.repo_id = p_repo_id AND c.hash = r.commit_hash
+               array_agg(r.name) FILTER (WHERE r.name <> 'HEAD') as ref_names
+        FROM pggit.get_log(p_repo_id, p_limit) c
+        LEFT JOIN pggit.refs r ON r.repo_id = p_repo_id AND c.hash = r.commit_hash
         GROUP BY c.hash, c.message, c.author, c.timestamp
     )
     SELECT 
@@ -64,12 +65,12 @@ BEGIN
             E'\n',
             author,
             E'\n',
-            timestamp,
+            "timestamp",
             E'\n',
             E'\n    ',
             message
         ) as commit_line,
         ref_names
     FROM commit_refs
-    ORDER BY timestamp DESC;
+    ORDER BY "timestamp" DESC;
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/005-status.sql
+++ b/sql/functions/005-status.sql
@@ -1,21 +1,21 @@
 -- Path: /sql/functions/005-status.sql
 -- pg_git status functions
 
-CREATE OR REPLACE FUNCTION pg_git.get_status(
+CREATE OR REPLACE FUNCTION pggit.get_status(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     path TEXT,
     status TEXT,
     staged BOOLEAN
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_head_commit TEXT;
     v_head_tree TEXT;
 BEGIN
     -- Get HEAD commit and tree
     SELECT c.hash, c.tree_hash INTO v_head_commit, v_head_tree
-    FROM pg_git.refs r
-    JOIN pg_git.commits c ON r.repo_id = p_repo_id AND c.repo_id = r.repo_id AND r.commit_hash = c.hash
+    FROM pggit.refs r
+    JOIN pggit.commits c ON r.repo_id = p_repo_id AND c.repo_id = r.repo_id AND r.commit_hash = c.hash
     WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
 
     RETURN QUERY
@@ -35,15 +35,15 @@ BEGIN
         END,
         TRUE
     FROM index_entries i
-    LEFT JOIN pg_git.trees t ON t.repo_id = p_repo_id AND t.hash = v_head_tree
+    LEFT JOIN pggit.trees t ON t.repo_id = p_repo_id AND t.hash = v_head_tree
     WHERE i.repo_id = p_repo_id;
 END;
 $$ LANGUAGE plpgsql;
 
 -- Pretty format version
-CREATE OR REPLACE FUNCTION pg_git.get_formatted_status(
+CREATE OR REPLACE FUNCTION pggit.get_formatted_status(
     p_repo_id INTEGER
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_output TEXT;
 BEGIN
@@ -54,7 +54,7 @@ BEGIN
         END,
         E'\n'
     ) INTO v_output
-    FROM pg_git.get_status(p_repo_id)
+    FROM pggit.get_status(p_repo_id)
     WHERE status IS NOT NULL;
 
     RETURN format(

--- a/sql/functions/006-branch.sql
+++ b/sql/functions/006-branch.sql
@@ -1,70 +1,70 @@
 -- Path: /sql/functions/006-branch.sql
 -- pg_git branch operations
 
-CREATE OR REPLACE FUNCTION pg_git.create_branch(
+CREATE OR REPLACE FUNCTION pggit.create_branch(
     p_repo_id INTEGER,
     p_branch_name TEXT,
     p_start_point TEXT DEFAULT NULL
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_commit_hash TEXT;
 BEGIN
     -- Get commit hash from start point or HEAD
     IF p_start_point IS NULL THEN
         SELECT commit_hash INTO v_commit_hash
-        FROM pg_git.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
     ELSE
         v_commit_hash := p_start_point;
     END IF;
 
     -- Create branch reference
-    INSERT INTO pg_git.refs (repo_id, name, commit_hash)
+    INSERT INTO pggit.refs (repo_id, name, commit_hash)
     VALUES (p_repo_id, p_branch_name, v_commit_hash);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.list_branches(
+CREATE OR REPLACE FUNCTION pggit.list_branches(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     name TEXT,
     commit_hash TEXT,
     is_current BOOLEAN
-) AS $$
+) SET search_path = pggit, public AS $$
 SELECT 
     r.name,
     r.commit_hash,
     r.commit_hash = head.commit_hash AS is_current
-FROM pg_git.refs r
-CROSS JOIN (SELECT commit_hash FROM pg_git.refs WHERE repo_id = p_repo_id AND name = 'HEAD') head
+FROM pggit.refs r
+CROSS JOIN (SELECT commit_hash FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD') head
 WHERE r.repo_id = p_repo_id AND r.name != 'HEAD'
 ORDER BY r.name;
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.checkout_branch(
+CREATE OR REPLACE FUNCTION pggit.checkout_branch(
     p_repo_id INTEGER,
     p_branch_name TEXT,
     p_create BOOLEAN DEFAULT FALSE
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_commit_hash TEXT;
 BEGIN
     -- Get branch commit
     SELECT commit_hash INTO v_commit_hash
-    FROM pg_git.refs WHERE repo_id = p_repo_id AND name = p_branch_name;
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_branch_name;
     
     IF NOT FOUND AND p_create THEN
         -- Create new branch from HEAD
         SELECT commit_hash INTO v_commit_hash
-        FROM pg_git.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
         
-        INSERT INTO pg_git.refs (repo_id, name, commit_hash)
+        INSERT INTO pggit.refs (repo_id, name, commit_hash)
         VALUES (p_repo_id, p_branch_name, v_commit_hash);
     ELSIF NOT FOUND THEN
         RAISE EXCEPTION 'Branch % does not exist', p_branch_name;
     END IF;
 
     -- Update HEAD
-    UPDATE pg_git.refs SET commit_hash = v_commit_hash
+    UPDATE pggit.refs SET commit_hash = v_commit_hash
     WHERE repo_id = p_repo_id AND name = 'HEAD';
 
     RETURN v_commit_hash;

--- a/sql/functions/007-merge.sql
+++ b/sql/functions/007-merge.sql
@@ -1,91 +1,92 @@
 -- Path: /sql/functions/007-merge.sql
 -- pg_git merge operations
 
-CREATE OR REPLACE FUNCTION pg_git.find_merge_base(
-    p_repo_id INTEGER,
+-- Most recent common ancestor of two commits. Commit hashes are globally unique,
+-- so the repository is implied by the commits themselves. A recursive CTE allows
+-- only one non-recursive and one recursive term, so each ancestor walk is its own
+-- recursive CTE and the two are intersected.
+CREATE OR REPLACE FUNCTION pggit.find_merge_base(
     p_commit1 TEXT,
     p_commit2 TEXT
-) RETURNS TEXT AS $$
-WITH RECURSIVE commit_ancestors AS (
-    -- Get all ancestors of commit1
-    SELECT hash, parent_hash, 1 AS source
-    FROM pg_git.commits 
+) RETURNS TEXT SET search_path = pggit, public AS $$
+WITH RECURSIVE ancestors1 AS (
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
     WHERE hash = p_commit1
     UNION ALL
-    SELECT c.hash, c.parent_hash, 1
-    FROM pg_git.commits c
-    JOIN commit_ancestors ca ON ca.parent_hash = c.hash
-    WHERE ca.source = 1 AND c.repo_id = p_repo_id
-
-    UNION ALL
-
-    -- Get all ancestors of commit2
-    SELECT hash, parent_hash, 2 AS source
-    FROM pg_git.commits 
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestors1 a ON a.repo_id = c.repo_id AND a.parent_hash = c.hash
+),
+ancestors2 AS (
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
     WHERE hash = p_commit2
     UNION ALL
-    SELECT c.hash, c.parent_hash, 2
-    FROM pg_git.commits c
-    JOIN commit_ancestors ca ON ca.parent_hash = c.hash
-    WHERE ca.source = 2 AND c.repo_id = p_repo_id
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestors2 a ON a.repo_id = c.repo_id AND a.parent_hash = c.hash
 )
-SELECT hash
-FROM (
-    SELECT hash, array_agg(DISTINCT source) as sources
-    FROM commit_ancestors
-    GROUP BY hash
-) a
-WHERE array_length(sources, 1) > 1
-ORDER BY (SELECT timestamp FROM pg_git.commits WHERE hash = a.hash) DESC
+SELECT c.hash
+FROM ancestors1 a1
+JOIN ancestors2 a2 ON a1.repo_id = a2.repo_id AND a1.hash = a2.hash
+JOIN pggit.commits c ON c.repo_id = a1.repo_id AND c.hash = a1.hash
+ORDER BY c.timestamp DESC
 LIMIT 1;
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.can_fast_forward(
-    p_repo_id INTEGER,
+-- True when p_source is an ancestor of p_target, i.e. p_target can be
+-- fast-forwarded onto p_source's history (p_source is reachable from p_target).
+CREATE OR REPLACE FUNCTION pggit.can_fast_forward(
     p_source TEXT,
     p_target TEXT
-) RETURNS BOOLEAN AS $$
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
 WITH RECURSIVE ancestor_chain AS (
-    SELECT hash, parent_hash
-    FROM pg_git.commits
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
     WHERE hash = p_target
     UNION ALL
-    SELECT c.hash, c.parent_hash
-    FROM pg_git.commits c
-    JOIN ancestor_chain ac ON ac.parent_hash = c.hash
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestor_chain ac ON ac.repo_id = c.repo_id AND ac.parent_hash = c.hash
 )
 SELECT EXISTS (
     SELECT 1 FROM ancestor_chain WHERE hash = p_source
 );
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.merge_branches(
+CREATE OR REPLACE FUNCTION pggit.merge_branches(
     p_repo_id INTEGER,
     p_source_branch TEXT,
     p_target_branch TEXT DEFAULT 'HEAD'
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_source_commit TEXT;
     v_target_commit TEXT;
-    v_merge_base TEXT;
 BEGIN
-    -- Get commit hashes
+    -- Resolve both branches, failing clearly if either is missing.
     SELECT commit_hash INTO v_source_commit
-    FROM pg_git.refs WHERE repo_id = p_repo_id AND name = p_source_branch;
-    
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_source_branch;
+    IF v_source_commit IS NULL THEN
+        RAISE EXCEPTION 'Branch % does not exist', p_source_branch;
+    END IF;
+
     SELECT commit_hash INTO v_target_commit
-    FROM pg_git.refs WHERE repo_id = p_repo_id AND name = p_target_branch;
-    
-    -- Check if fast-forward is possible
-    IF pg_git.can_fast_forward(p_repo_id, v_source_commit, v_target_commit) THEN
-        -- Fast-forward merge
-        UPDATE pg_git.refs
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_target_branch;
+    IF v_target_commit IS NULL THEN
+        RAISE EXCEPTION 'Branch % does not exist', p_target_branch;
+    END IF;
+
+    -- Fast-forward is possible when the target commit is an ancestor of the
+    -- source commit; advance the target ref to the source commit.
+    IF pggit.can_fast_forward(v_target_commit, v_source_commit) THEN
+        UPDATE pggit.refs
         SET commit_hash = v_source_commit
         WHERE repo_id = p_repo_id AND name = p_target_branch;
-        
+
         RETURN v_source_commit;
     END IF;
-    
+
     -- For now, only support fast-forward merges
     RAISE EXCEPTION 'Only fast-forward merges are currently supported';
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/008-diff.sql
+++ b/sql/functions/008-diff.sql
@@ -1,39 +1,40 @@
 -- Path: /sql/functions/008-diff.sql
 -- pg_git diff operations
 
-CREATE OR REPLACE FUNCTION pg_git.diff_blobs(
+CREATE OR REPLACE FUNCTION pggit.diff_blobs(
     p_old_hash TEXT,
     p_new_hash TEXT
 ) RETURNS TABLE (
-    line_type CHAR(1),
+    line_type TEXT,
     line_content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_old_content TEXT;
     v_new_content TEXT;
 BEGIN
-    -- Get content from pg_git.blobs
+    -- Get content from pggit.blobs
     SELECT encode(content, 'escape') INTO v_old_content
-    FROM pg_git.blobs WHERE hash = p_old_hash;
+    FROM pggit.blobs WHERE hash = p_old_hash;
     
     SELECT encode(content, 'escape') INTO v_new_content
-    FROM pg_git.blobs WHERE hash = p_new_hash;
+    FROM pggit.blobs WHERE hash = p_new_hash;
     
     RETURN QUERY
     SELECT *
-    FROM pg_git.diff_text(v_old_content, v_new_content);
+    FROM pggit.diff_text(v_old_content, v_new_content);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.diff_text(
+CREATE OR REPLACE FUNCTION pggit.diff_text(
     p_old_text TEXT,
     p_new_text TEXT
 ) RETURNS TABLE (
-    line_type CHAR(1),
+    line_type TEXT,
     line_content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     -- Split texts into arrays with line numbers using ordinality
+    RETURN QUERY
     WITH old_lines AS (
         SELECT line, line_num
         FROM unnest(string_to_array(p_old_text, E'\n')) WITH ORDINALITY AS t(line, line_num)
@@ -42,8 +43,9 @@ BEGIN
         SELECT line, line_num
         FROM unnest(string_to_array(p_new_text, E'\n')) WITH ORDINALITY AS t(line, line_num)
     )
-    -- Simple line-by-line diff preserving line order
-    SELECT line_type, line_content
+    -- Simple line-by-line diff preserving line order. Columns are qualified with
+    -- the subquery alias to avoid ambiguity with the RETURNS TABLE OUT columns.
+    SELECT d.line_type, d.line_content
     FROM (
         SELECT line_num, '-' AS line_type, old_lines.line AS line_content
         FROM old_lines
@@ -59,18 +61,18 @@ BEGIN
         FROM old_lines
         JOIN new_lines USING (line_num, line)
     ) d
-    ORDER BY line_num, CASE line_type WHEN '-' THEN 1 WHEN '+' THEN 2 ELSE 3 END;
+    ORDER BY d.line_num, CASE d.line_type WHEN '-' THEN 1 WHEN '+' THEN 2 ELSE 3 END;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.diff_commits(
+CREATE OR REPLACE FUNCTION pggit.diff_commits(
     p_old_commit TEXT,
     p_new_commit TEXT
 ) RETURNS TABLE (
     path TEXT,
     change_type TEXT,
     diff_content TEXT[]
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_repo_id INTEGER;
     v_old_tree TEXT;
@@ -78,15 +80,15 @@ DECLARE
 BEGIN
     -- Get tree hashes
     SELECT repo_id, tree_hash INTO v_repo_id, v_old_tree
-    FROM pg_git.commits WHERE hash = p_old_commit;
+    FROM pggit.commits WHERE hash = p_old_commit;
 
     IF v_repo_id IS NULL THEN
         SELECT repo_id INTO v_repo_id
-        FROM pg_git.commits WHERE hash = p_new_commit;
+        FROM pggit.commits WHERE hash = p_new_commit;
     END IF;
 
     SELECT tree_hash INTO v_new_tree
-    FROM pg_git.commits WHERE hash = p_new_commit AND repo_id = v_repo_id;
+    FROM pggit.commits WHERE hash = p_new_commit AND repo_id = v_repo_id;
 
     RETURN QUERY
     SELECT
@@ -96,10 +98,10 @@ BEGIN
             WHEN d.change_type = 'modified' THEN
                 ARRAY(
                     SELECT line_type || line_content
-                    FROM pg_git.diff_blobs(d.old_hash, d.new_hash)
+                    FROM pggit.diff_blobs(d.old_hash, d.new_hash)
                 )
             ELSE
                 ARRAY[]::TEXT[]
         END as diff_content
-    FROM pg_git.diff_trees(v_repo_id, v_old_tree, v_new_tree) d;
+    FROM pggit.diff_trees(v_repo_id, v_old_tree, v_new_tree) d;
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/009-reset.sql
+++ b/sql/functions/009-reset.sql
@@ -1,45 +1,45 @@
 -- Path: /sql/functions/009-reset.sql
 -- pg_git reset operations
 
-CREATE OR REPLACE FUNCTION pg_git.reset_soft(
+CREATE OR REPLACE FUNCTION pggit.reset_soft(
     p_repo_id INTEGER,
     p_commit TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
     -- Move HEAD to specified commit
-    UPDATE pg_git.refs
+    UPDATE pggit.refs
     SET commit_hash = p_commit
     WHERE repo_id = p_repo_id AND name = 'HEAD';
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.reset_mixed(
+CREATE OR REPLACE FUNCTION pggit.reset_mixed(
     p_repo_id INTEGER,
     p_commit TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
     -- Move HEAD and clear index
-    PERFORM pg_git.reset_soft(p_repo_id, p_commit);
+    PERFORM pggit.reset_soft(p_repo_id, p_commit);
     DELETE FROM index_entries WHERE repo_id = p_repo_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.reset_file(
+CREATE OR REPLACE FUNCTION pggit.reset_file(
     p_repo_id INTEGER,
     p_path TEXT,
     p_commit TEXT DEFAULT 'HEAD'
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_tree_hash TEXT;
     v_blob_hash TEXT;
 BEGIN
     -- Get tree from commit
     SELECT tree_hash INTO v_tree_hash
-    FROM pg_git.commits WHERE repo_id = p_repo_id AND hash = p_commit;
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_commit;
     
     -- Get blob hash from tree
     SELECT (e->>'hash')::TEXT INTO v_blob_hash
-    FROM pg_git.trees t,
+    FROM pggit.trees t,
     jsonb_array_elements(t.entries) e
     WHERE t.repo_id = p_repo_id AND t.hash = v_tree_hash
     AND e->>'name' = p_path;

--- a/sql/functions/010-tag.sql
+++ b/sql/functions/010-tag.sql
@@ -1,8 +1,8 @@
 -- Path: /sql/functions/010-tag.sql
 -- pg_git tag operations
 
-CREATE TABLE pg_git.tags (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.tags (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     name TEXT NOT NULL,
     target_hash TEXT NOT NULL,
     tagger TEXT NOT NULL,
@@ -11,30 +11,30 @@ CREATE TABLE pg_git.tags (
     PRIMARY KEY (repo_id, name)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.create_tag(
+CREATE OR REPLACE FUNCTION pggit.create_tag(
     p_repo_id INTEGER,
     p_name TEXT,
     p_target TEXT DEFAULT 'HEAD',
     p_tagger TEXT DEFAULT current_user,
     p_message TEXT DEFAULT NULL
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_target_hash TEXT;
 BEGIN
     -- Resolve target to commit hash
     IF p_target = 'HEAD' THEN
         SELECT commit_hash INTO v_target_hash
-        FROM pg_git.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
     ELSE
         v_target_hash := p_target;
     END IF;
 
-    INSERT INTO pg_git.tags (repo_id, name, target_hash, tagger, message)
+    INSERT INTO pggit.tags (repo_id, name, target_hash, tagger, message)
     VALUES (p_repo_id, p_name, v_target_hash, p_tagger, p_message);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.list_tags(
+CREATE OR REPLACE FUNCTION pggit.list_tags(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     name TEXT,
@@ -42,8 +42,8 @@ CREATE OR REPLACE FUNCTION pg_git.list_tags(
     tagger TEXT,
     message TEXT,
     created_at TIMESTAMP WITH TIME ZONE
-) AS $$
+) SET search_path = pggit, public AS $$
     SELECT name, target_hash, tagger, message, created_at
-    FROM pg_git.tags
+    FROM pggit.tags
     WHERE repo_id = p_repo_id
     ORDER BY created_at DESC;$$ LANGUAGE sql;

--- a/sql/functions/011-remote.sql
+++ b/sql/functions/011-remote.sql
@@ -1,59 +1,59 @@
 -- Path: /sql/functions/011-remote.sql
 -- pg_git remote operations
 
-CREATE TABLE pg_git.remotes (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.remotes (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     name TEXT NOT NULL,
     url TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, name)
 );
 
-CREATE TABLE pg_git.remote_refs (
+CREATE TABLE pggit.remote_refs (
     repo_id INTEGER,
     remote_name TEXT,
     ref_name TEXT NOT NULL,
     commit_hash TEXT NOT NULL,
     last_fetch TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, remote_name, ref_name),
-    FOREIGN KEY (repo_id, remote_name) REFERENCES pg_git.remotes(repo_id, name)
+    FOREIGN KEY (repo_id, remote_name) REFERENCES pggit.remotes(repo_id, name)
 );
 
-COMMENT ON TABLE pg_git.remote_refs IS
+COMMENT ON TABLE pggit.remote_refs IS
     'Source of truth for fetched remote branch tips. fetch_remote materializes these into refs as <remote>/<branch> tracking refs.';
 
-CREATE OR REPLACE FUNCTION pg_git.add_remote(
+CREATE OR REPLACE FUNCTION pggit.add_remote(
     p_repo_id INTEGER,
     p_name TEXT,
     p_url TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.remotes (repo_id, name, url)
+    INSERT INTO pggit.remotes (repo_id, name, url)
     VALUES (p_repo_id, p_name, p_url);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.fetch_remote(
+CREATE OR REPLACE FUNCTION pggit.fetch_remote(
     p_repo_id INTEGER,
     p_remote_name TEXT
 ) RETURNS TABLE (
     ref_name TEXT,
     old_hash TEXT,
     new_hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_remote_url TEXT;
 BEGIN
     -- Get remote URL
     SELECT url INTO v_remote_url
-    FROM pg_git.remotes
+    FROM pggit.remotes
     WHERE repo_id = p_repo_id AND name = p_remote_name;
 
     IF NOT FOUND THEN
         RAISE EXCEPTION 'Remote % does not exist for repo %', p_remote_name, p_repo_id;
     END IF;
 
-    -- Source of truth: pg_git.remote_refs stores fetched remote branch tips.
+    -- Source of truth: pggit.remote_refs stores fetched remote branch tips.
     -- Materialized remote-tracking refs in refs are derived as <remote>/<branch>.
     RETURN QUERY
     WITH tracking AS (
@@ -61,7 +61,7 @@ BEGIN
             rr.ref_name,
             (p_remote_name || '/' || rr.ref_name) AS tracking_ref,
             rr.commit_hash AS remote_hash
-        FROM pg_git.remote_refs rr
+        FROM pggit.remote_refs rr
         WHERE rr.repo_id = p_repo_id
           AND rr.remote_name = p_remote_name
     ),
@@ -88,23 +88,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.push(
+CREATE OR REPLACE FUNCTION pggit.push(
     p_repo_id INTEGER,
     p_remote_name TEXT,
     p_ref_name TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_remote_url TEXT;
     v_commit_hash TEXT;
 BEGIN
     -- Get remote URL
     SELECT url INTO v_remote_url
-    FROM pg_git.remotes
+    FROM pggit.remotes
     WHERE repo_id = p_repo_id AND name = p_remote_name;
 
     -- Get local ref
     SELECT commit_hash INTO v_commit_hash
-    FROM pg_git.refs WHERE repo_id = p_repo_id AND name = p_ref_name;
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_ref_name;
 
     -- In a real implementation, this would:
     -- 1. Connect to remote database
@@ -114,16 +114,16 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.pull(
+CREATE OR REPLACE FUNCTION pggit.pull(
     p_repo_id INTEGER,
     p_remote_name TEXT,
     p_ref_name TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_tracking_ref TEXT;
 BEGIN
     -- Fetch from remote
-    PERFORM pg_git.fetch_remote(p_repo_id, p_remote_name);
+    PERFORM pggit.fetch_remote(p_repo_id, p_remote_name);
 
     v_tracking_ref := p_remote_name || '/' || p_ref_name;
 
@@ -137,7 +137,7 @@ BEGIN
     END IF;
 
     -- Merge verified remote-tracking ref into local branch
-    RETURN pg_git.merge_branches(
+    RETURN pggit.merge_branches(
         p_repo_id,
         v_tracking_ref,
         p_ref_name
@@ -145,25 +145,25 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.clone(
+CREATE OR REPLACE FUNCTION pggit.clone(
     p_url TEXT,
     p_name TEXT,
     p_path TEXT
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_repo_id INTEGER;
 BEGIN
     -- Create new repo
-    v_repo_id := pg_git.init_repository(p_name, p_path);
+    v_repo_id := pggit.init_repository(p_name, p_path);
     
     -- Add remote
-    PERFORM pg_git.add_remote(v_repo_id, 'origin', p_url);
+    PERFORM pggit.add_remote(v_repo_id, 'origin', p_url);
     
     -- Fetch everything
-    PERFORM pg_git.fetch_remote(v_repo_id, 'origin');
+    PERFORM pggit.fetch_remote(v_repo_id, 'origin');
     
     -- Checkout main branch
-    PERFORM pg_git.checkout_branch(v_repo_id, 'main', TRUE);
+    PERFORM pggit.checkout_branch(v_repo_id, 'main', TRUE);
     
     RETURN v_repo_id;
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/012-migrations.sql
+++ b/sql/functions/012-migrations.sql
@@ -1,24 +1,24 @@
 -- Path: /sql/functions/012-migrations.sql
 -- pg_git schema migrations
 
-CREATE TABLE pg_git.schema_migrations (
+CREATE TABLE pggit.schema_migrations (
     version INTEGER PRIMARY KEY,
     applied_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE OR REPLACE FUNCTION pg_git.get_current_schema_version()
-RETURNS INTEGER AS $$
-    SELECT COALESCE(MAX(version), 0) FROM pg_git.schema_migrations;
+CREATE OR REPLACE FUNCTION pggit.get_current_schema_version()
+RETURNS INTEGER SET search_path = pggit, public AS $$
+    SELECT COALESCE(MAX(version), 0) FROM pggit.schema_migrations;
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.run_migration(
+CREATE OR REPLACE FUNCTION pggit.run_migration(
     p_version INTEGER,
     p_up TEXT,
     p_down TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    IF p_version > pg_git.get_current_schema_version() THEN
+    IF p_version > pggit.get_current_schema_version() THEN
         EXECUTE p_up;
-        INSERT INTO pg_git.schema_migrations (version) VALUES (p_version);
+        INSERT INTO pggit.schema_migrations (version) VALUES (p_version);
     END IF;
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/013-merge-conflicts.sql
+++ b/sql/functions/013-merge-conflicts.sql
@@ -1,44 +1,48 @@
 -- Path: /sql/functions/013-merge-conflicts.sql
 -- pg_git merge conflict resolution
 
-CREATE TABLE pg_git.merge_conflicts (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.merge_conflicts (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     path TEXT NOT NULL,
-    our_blob_hash TEXT REFERENCES pg_git.blobs(hash),
-    their_blob_hash TEXT REFERENCES pg_git.blobs(hash),
-    base_blob_hash TEXT REFERENCES pg_git.blobs(hash),
-    resolution_blob_hash TEXT REFERENCES pg_git.blobs(hash),
+    our_blob_hash TEXT,
+    their_blob_hash TEXT,
+    base_blob_hash TEXT,
+    resolution_blob_hash TEXT,
     status TEXT CHECK (status IN ('unresolved', 'resolved', 'ignored')),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, path)
+    PRIMARY KEY (repo_id, path),
+    FOREIGN KEY (repo_id, our_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, their_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, base_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.detect_conflicts(
+CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
     p_repo_id INTEGER,
     p_our_commit TEXT,
     p_their_commit TEXT
 ) RETURNS TABLE (
     path TEXT,
     conflict_type TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_base_commit TEXT;
 BEGIN
     -- Find merge base
-    v_base_commit := pg_git.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
+    v_base_commit := pggit.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
     
     RETURN QUERY
     WITH our_files AS (
         SELECT path, blob_hash
-        FROM pg_git.get_tree_files(p_our_commit)
+        FROM pggit.get_tree_files(p_our_commit)
     ),
     their_files AS (
         SELECT path, blob_hash
-        FROM pg_git.get_tree_files(p_their_commit)
+        FROM pggit.get_tree_files(p_their_commit)
     ),
     base_files AS (
         SELECT path, blob_hash
-        FROM pg_git.get_tree_files(v_base_commit)
+        FROM pggit.get_tree_files(v_base_commit)
     )
     SELECT DISTINCT f.path,
            CASE
@@ -54,5 +58,5 @@ BEGIN
     LEFT JOIN their_files t ON f.path = t.path
     LEFT JOIN base_files b ON f.path = b.path
     WHERE (o.blob_hash != t.blob_hash OR o.blob_hash IS NULL OR t.blob_hash IS NULL)
-    AND NOT pg_git.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
+    AND NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
 END;$$ LANGUAGE plpgsql;

--- a/sql/functions/014-https.sql
+++ b/sql/functions/014-https.sql
@@ -1,8 +1,8 @@
 -- Path: /sql/functions/014-https.sql
 -- pg_git HTTPS transport
 
-CREATE TABLE pg_git.credentials (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.credentials (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     host TEXT NOT NULL,
     username TEXT NOT NULL,
     password BYTEA NOT NULL,
@@ -10,16 +10,16 @@ CREATE TABLE pg_git.credentials (
     PRIMARY KEY (repo_id, host)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.store_credentials(
+CREATE OR REPLACE FUNCTION pggit.store_credentials(
     p_repo_id INTEGER,
     p_host TEXT,
     p_username TEXT,
     p_password TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
-    v_key TEXT := current_setting('pg_git.credential_key', true);
+    v_key TEXT := current_setting('pggit.credential_key', true);
 BEGIN
-    INSERT INTO pg_git.credentials (repo_id, host, username, password)
+    INSERT INTO pggit.credentials (repo_id, host, username, password)
     VALUES (
         p_repo_id,
         p_host,
@@ -32,21 +32,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.http_fetch(
+CREATE OR REPLACE FUNCTION pggit.http_fetch(
     p_repo_id INTEGER,
     p_url TEXT
-) RETURNS BYTEA AS $$import base64
+) RETURNS BYTEA SET search_path = pggit, public AS $$import base64
 import ssl
 from urllib.parse import urlparse
 import urllib.request
 import urllib.error
 
 host = urlparse(p_url).hostname
-key = plpy.execute("SELECT current_setting('pg_git.credential_key', true) AS k")[0]['k'] or 'pg_git_default_key'
-cred = plpy.execute(
-    "SELECT username, pgp_sym_decrypt(password, $1) AS pw FROM pg_git.credentials WHERE repo_id = $2 AND host = $3",
-    [key, p_repo_id, host]
+key = plpy.execute("SELECT current_setting('pggit.credential_key', true) AS k")[0]['k'] or 'pg_git_default_key'
+# Parameterized queries require a prepared plan; plpy.execute(query, x) treats x
+# as a row limit, not bind parameters.
+cred_plan = plpy.prepare(
+    "SELECT username, pgp_sym_decrypt(password, $1) AS pw FROM pggit.credentials WHERE repo_id = $2 AND host = $3",
+    ["text", "integer", "text"]
 )
+cred = plpy.execute(cred_plan, [key, p_repo_id, host])
 
 context = ssl.create_default_context()
 

--- a/sql/functions/015-admin.sql
+++ b/sql/functions/015-admin.sql
@@ -1,13 +1,13 @@
 -- Path: /sql/functions/015-admin.sql
 -- pg_git admin functions
 
-CREATE OR REPLACE FUNCTION pg_git.gc(
+CREATE OR REPLACE FUNCTION pggit.gc(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     object_type TEXT,
     objects_removed INTEGER,
     space_reclaimed BIGINT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     -- Ensure temporary table does not exist from prior runs
     DROP TABLE IF EXISTS tmp_reachable_objects;
@@ -15,29 +15,34 @@ BEGIN
     -- Collect all reachable objects into a temporary table
     CREATE TEMP TABLE tmp_reachable_objects(hash TEXT PRIMARY KEY) ON COMMIT DROP;
 
+    -- PostgreSQL recursive CTEs allow only a single self-reference in the
+    -- recursive term, so the different edge types (commit->parent, commit->tree,
+    -- tree->entries) are expanded in one LATERAL branch off the working row.
     WITH RECURSIVE reachable(object_type, hash) AS (
-        -- Start from pg_git.refs
-        SELECT 'commit', commit_hash FROM pg_git.refs WHERE repo_id = p_repo_id
+        -- Start from pggit.refs
+        SELECT 'commit'::TEXT, commit_hash FROM pggit.refs WHERE repo_id = p_repo_id
         UNION
-        -- Walk parent pg_git.commits
-        SELECT 'commit', c.parent_hash
-        FROM pg_git.commits c
-        JOIN reachable r
-          ON r.object_type = 'commit' AND c.repo_id = p_repo_id AND c.hash = r.hash
-        WHERE c.parent_hash IS NOT NULL
-        UNION
-        -- Commits reference pg_git.trees
-        SELECT 'tree', c.tree_hash
-        FROM pg_git.commits c
-        JOIN reachable r
-          ON r.object_type = 'commit' AND c.repo_id = p_repo_id AND c.hash = r.hash
-        UNION
-        -- Trees reference pg_git.blobs and subtrees
-        SELECT (e->>'type')::TEXT, e->>'hash'
-        FROM pg_git.trees t
-        JOIN reachable r
-          ON r.object_type = 'tree' AND t.repo_id = p_repo_id AND t.hash = r.hash
-        CROSS JOIN LATERAL jsonb_array_elements(t.entries) AS e
+        SELECT nxt.object_type, nxt.hash
+        FROM reachable r
+        CROSS JOIN LATERAL (
+            -- Walk parent commits
+            SELECT 'commit'::TEXT AS object_type, c.parent_hash AS hash
+            FROM pggit.commits c
+            WHERE r.object_type = 'commit' AND c.repo_id = p_repo_id
+              AND c.hash = r.hash AND c.parent_hash IS NOT NULL
+            UNION ALL
+            -- Commits reference trees
+            SELECT 'tree'::TEXT, c.tree_hash
+            FROM pggit.commits c
+            WHERE r.object_type = 'commit' AND c.repo_id = p_repo_id AND c.hash = r.hash
+            UNION ALL
+            -- Trees reference blobs and subtrees
+            SELECT (e->>'type')::TEXT, e->>'hash'
+            FROM pggit.trees t
+            CROSS JOIN LATERAL jsonb_array_elements(t.entries) AS e
+            WHERE r.object_type = 'tree' AND t.repo_id = p_repo_id AND t.hash = r.hash
+        ) nxt
+        WHERE nxt.hash IS NOT NULL
     )
     INSERT INTO tmp_reachable_objects
     SELECT DISTINCT hash FROM reachable;
@@ -45,33 +50,33 @@ BEGIN
     -- Remove unreachable objects
     RETURN QUERY
     WITH deleted_blobs AS (
-        DELETE FROM pg_git.blobs b
+        DELETE FROM pggit.blobs b
         WHERE b.repo_id = p_repo_id AND NOT EXISTS (
             SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = b.hash
         )
         RETURNING octet_length(content) AS size
     ), deleted_trees AS (
-        DELETE FROM pg_git.trees t
+        DELETE FROM pggit.trees t
         WHERE t.repo_id = p_repo_id AND NOT EXISTS (
             SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = t.hash
         )
         RETURNING octet_length(entries::TEXT) AS size
     ), deleted_commits AS (
-        DELETE FROM pg_git.commits c
+        DELETE FROM pggit.commits c
         WHERE c.repo_id = p_repo_id AND NOT EXISTS (
             SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = c.hash
         )
         RETURNING octet_length(message) AS size
     )
-    SELECT 'pg_git.blobs'::TEXT,
+    SELECT 'blobs'::TEXT,
            count(*)::INTEGER,
            COALESCE(sum(size),0)::BIGINT FROM deleted_blobs
     UNION ALL
-    SELECT 'pg_git.trees'::TEXT,
+    SELECT 'trees'::TEXT,
            count(*)::INTEGER,
            COALESCE(sum(size),0)::BIGINT FROM deleted_trees
     UNION ALL
-    SELECT 'pg_git.commits'::TEXT,
+    SELECT 'commits'::TEXT,
            count(*)::INTEGER,
            COALESCE(sum(size),0)::BIGINT FROM deleted_commits;
 
@@ -80,82 +85,77 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.verify_integrity(
+CREATE OR REPLACE FUNCTION pggit.verify_integrity(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     check_type TEXT,
     status TEXT,
     details TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
-    -- Check dangling pg_git.commits
+    -- Check dangling pggit.commits
     RETURN QUERY
     SELECT 'dangling_commits'::TEXT,
            CASE WHEN count(*) = 0 THEN 'ok' ELSE 'warning' END,
-           count(*) || ' dangling pg_git.commits found'
-    FROM pg_git.commits c
+           count(*) || ' dangling pggit.commits found'
+    FROM pggit.commits c
     WHERE c.repo_id = p_repo_id
-      AND NOT EXISTS (SELECT 1 FROM pg_git.refs r WHERE r.repo_id = p_repo_id AND r.commit_hash = c.hash);
+      AND NOT EXISTS (SELECT 1 FROM pggit.refs r WHERE r.repo_id = p_repo_id AND r.commit_hash = c.hash);
 
     -- Check broken parent links
     RETURN QUERY
     SELECT 'broken_parents'::TEXT,
            CASE WHEN count(*) = 0 THEN 'ok' ELSE 'error' END,
-           count(*) || ' pg_git.commits with invalid parent references'
-    FROM pg_git.commits c
+           count(*) || ' pggit.commits with invalid parent references'
+    FROM pggit.commits c
     WHERE c.repo_id = p_repo_id
       AND c.parent_hash IS NOT NULL
-      AND NOT EXISTS (SELECT 1 FROM pg_git.commits p WHERE p.repo_id = p_repo_id AND p.hash = c.parent_hash);
+      AND NOT EXISTS (SELECT 1 FROM pggit.commits p WHERE p.repo_id = p_repo_id AND p.hash = c.parent_hash);
     
     -- Check broken tree references
     RETURN QUERY
     SELECT 'broken_trees'::TEXT,
            CASE WHEN count(*) = 0 THEN 'ok' ELSE 'error' END,
-           count(*) || ' pg_git.commits with invalid tree references'
-    FROM pg_git.commits c
+           count(*) || ' pggit.commits with invalid tree references'
+    FROM pggit.commits c
     WHERE c.repo_id = p_repo_id
-      AND NOT EXISTS (SELECT 1 FROM pg_git.trees t WHERE t.repo_id = p_repo_id AND t.hash = c.tree_hash);
+      AND NOT EXISTS (SELECT 1 FROM pggit.trees t WHERE t.repo_id = p_repo_id AND t.hash = c.tree_hash);
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.optimize_indexes(
+CREATE OR REPLACE FUNCTION pggit.optimize_indexes(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     table_name TEXT,
     index_name TEXT,
     operation TEXT,
     success BOOLEAN
-) AS $$
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_table TEXT;
+    v_index TEXT;
 BEGIN
-    -- Temporary table to collect reindex results
-    CREATE TEMP TABLE IF NOT EXISTS optimize_index_results (
-        table_name TEXT,
-        index_name TEXT,
-        operation TEXT,
-        success BOOLEAN
-    ) ON COMMIT DROP;
-    TRUNCATE optimize_index_results;
-
-    -- Perform reindex operations, logging successes and failures
-    FOR table_name, index_name IN
+    -- Reindex each index in the pggit schema, capturing per-index success.
+    -- Results are emitted with RETURN NEXT (no temp table) so the function makes
+    -- no catalog writes of its own and can run in a read-only transaction.
+    FOR v_table, v_index IN
         SELECT t.tablename::TEXT,
                i.indexname::TEXT
         FROM pg_tables t
-        JOIN pg_indexes i ON i.tablename = t.tablename
-        WHERE t.schemaname = 'pg_git'
+        JOIN pg_indexes i ON i.schemaname = t.schemaname AND i.tablename = t.tablename
+        WHERE t.schemaname = 'pggit'
+        ORDER BY t.tablename, i.indexname
     LOOP
+        table_name := v_table;
+        index_name := v_index;
+        operation := 'REINDEX';
         BEGIN
-            EXECUTE format('REINDEX INDEX %I', index_name);
-            INSERT INTO optimize_index_results VALUES (table_name, index_name, 'REINDEX', TRUE);
+            EXECUTE format('REINDEX INDEX pggit.%I', v_index);
+            success := TRUE;
         EXCEPTION WHEN OTHERS THEN
-            RAISE NOTICE 'Reindex failed for %: %', index_name, SQLERRM;
-            INSERT INTO optimize_index_results VALUES (table_name, index_name, 'REINDEX', FALSE);
+            RAISE NOTICE 'Reindex failed for %: %', v_index, SQLERRM;
+            success := FALSE;
         END;
+        RETURN NEXT;
     END LOOP;
-
-    -- Return results to caller
-    RETURN QUERY
-    SELECT table_name, index_name, operation, success
-    FROM optimize_index_results
-    ORDER BY table_name, index_name;
 END;$$ LANGUAGE plpgsql;

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -1,44 +1,3600 @@
--- pg_git extension load script
-CREATE SCHEMA IF NOT EXISTS pg_git;
-\ir schema/001-core.sql
-\ir schema/pgit-schema.sql
+-- pg_git 0.4.0
+-- GENERATED FILE -- DO NOT EDIT.
+-- Assembled from sql/schema/*.sql, sql/functions/*.sql and sql/pgit-*.sql.
+-- Regenerate with: make sql/pg_git--0.4.0.sql
 
-\ir functions/001-init.sql
-\ir functions/002-add.sql
-\ir functions/003-commit.sql
-\ir functions/004-log.sql
-\ir functions/005-status.sql
-\ir functions/006-branch.sql
-\ir functions/007-merge.sql
-\ir functions/008-diff.sql
-\ir functions/009-reset.sql
-\ir functions/010-tag.sql
-\ir functions/011-remote.sql
+-- ===== sql/schema/001-core.sql =====
+-- Core tables
+CREATE TABLE pggit.repositories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
 
-\ir functions/012-migrations.sql
-\ir functions/013-merge-conflicts.sql
-\ir functions/014-https.sql
-\ir functions/015-admin.sql
+CREATE TABLE pggit.blobs (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    hash TEXT,
+    content BYTEA NOT NULL,
+    PRIMARY KEY (repo_id, hash)
+);
 
-\i pgit-archive.sql
-\i pgit-advanced-commands.sql
-\i pgit-bundle.sql
-\i pgit-ci.sql
-\i pgit-diagnose.sql
-\i pgit-extras.sql
-\i pgit-instaweb.sql
-\i pgit-merge-tree.sql
-\i pgit-pack-refs.sql
-\i pgit-plumbing.sql
-\i pgit-repack.sql
-\i pgit-replace.sql
-\i pgit-rerere.sql
-\i pgit-sparse.sql
-\i pgit-submodule.sql
-\i pgit-update.sql
-\i pgit-verify-commit.sql
-\i pgit-verify-tag.sql
-\i pgit-version.sql
-\i pgit-version-updates.sql
-\i pgit-whatchanged.sql
-\i pgit-version-updates-0.2.0--0.3.0.sql
+CREATE TABLE pggit.trees (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    hash TEXT,
+    entries JSONB NOT NULL,  -- [{mode, type, hash, name}]
+    PRIMARY KEY (repo_id, hash)
+);
+
+CREATE TABLE pggit.commits (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    hash TEXT,
+    tree_hash TEXT NOT NULL,
+    parent_hash TEXT,
+    author TEXT NOT NULL,
+    message TEXT NOT NULL,
+    -- clock_timestamp() (not CURRENT_TIMESTAMP) so commits created within a single
+    -- transaction receive distinct, monotonically increasing timestamps and can be
+    -- ordered relative to one another.
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT clock_timestamp(),
+    PRIMARY KEY (repo_id, hash),
+    FOREIGN KEY (repo_id, tree_hash) REFERENCES pggit.trees(repo_id, hash),
+    FOREIGN KEY (repo_id, parent_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+CREATE TABLE pggit.refs (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    name TEXT,
+    commit_hash TEXT NOT NULL,
+    PRIMARY KEY (repo_id, name),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+-- Function to create a blob
+CREATE OR REPLACE FUNCTION create_blob(
+    p_repo_id INTEGER,
+    p_content BYTEA
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_hash TEXT;
+BEGIN
+    v_hash := encode(sha256(p_content), 'hex');
+    INSERT INTO pggit.blobs (repo_id, hash, content)
+    VALUES (p_repo_id, v_hash, p_content)
+    ON CONFLICT DO NOTHING;
+    RETURN v_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to create a tree
+CREATE OR REPLACE FUNCTION create_tree(
+    p_repo_id INTEGER,
+    p_entries JSONB
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_hash TEXT;
+BEGIN
+    v_hash := encode(sha256(p_entries::text::bytea), 'hex');
+    INSERT INTO pggit.trees (repo_id, hash, entries)
+    VALUES (p_repo_id, v_hash, p_entries)
+    ON CONFLICT DO NOTHING;
+    RETURN v_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to create a commit
+CREATE OR REPLACE FUNCTION create_commit(
+    p_repo_id INTEGER,
+    p_tree_hash TEXT,
+    p_parent_hash TEXT,
+    p_author TEXT,
+    p_message TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_hash TEXT;
+    v_commit_data TEXT;
+BEGIN
+    v_commit_data := concat_ws(
+        '',
+        COALESCE(p_tree_hash, ''),
+        COALESCE(p_parent_hash, ''),
+        COALESCE(p_author, ''),
+        COALESCE(p_message, '')
+    );
+    v_hash := encode(sha256(v_commit_data::bytea), 'hex');
+
+    IF v_hash IS NULL THEN
+        RAISE EXCEPTION 'Commit hash calculation returned NULL';
+    END IF;
+
+    INSERT INTO pggit.commits (repo_id, hash, tree_hash, parent_hash, author, message)
+    VALUES (p_repo_id, v_hash, p_tree_hash, p_parent_hash, p_author, p_message);
+    
+    RETURN v_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to create/update a branch
+CREATE OR REPLACE FUNCTION update_ref(
+    p_repo_id INTEGER,
+    p_name TEXT,
+    p_commit_hash TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.refs (repo_id, name, commit_hash)
+    VALUES (p_repo_id, p_name, p_commit_hash)
+    ON CONFLICT (repo_id, name) DO UPDATE
+    SET commit_hash = p_commit_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to get commit history
+CREATE OR REPLACE FUNCTION get_commit_history(
+    p_repo_id INTEGER,
+    p_start_commit TEXT
+) RETURNS TABLE (
+    hash TEXT,
+    tree_hash TEXT,
+    parent_hash TEXT,
+    author TEXT,
+    message TEXT,
+    "timestamp" TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
+WITH RECURSIVE commit_history AS (
+    SELECT * FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_start_commit
+    UNION ALL
+    SELECT c.*
+    FROM pggit.commits c
+    INNER JOIN commit_history ch ON c.repo_id = p_repo_id AND c.hash = ch.parent_hash
+)
+SELECT hash, tree_hash, parent_hash, author, message, "timestamp" FROM commit_history;
+$$ LANGUAGE sql;
+
+-- Function to diff two pggit.trees
+CREATE OR REPLACE FUNCTION diff_trees(
+    p_repo_id INTEGER,
+    p_old_tree_hash TEXT,
+    p_new_tree_hash TEXT
+) RETURNS TABLE (
+    change_type TEXT,
+    path TEXT,
+    old_hash TEXT,
+    new_hash TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_old_entries JSONB;
+    v_new_entries JSONB;
+BEGIN
+    -- Get tree entries
+    SELECT entries INTO v_old_entries FROM pggit.trees WHERE repo_id = p_repo_id AND hash = p_old_tree_hash;
+    SELECT entries INTO v_new_entries FROM pggit.trees WHERE repo_id = p_repo_id AND hash = p_new_tree_hash;
+    
+    -- Added files
+    RETURN QUERY
+    SELECT 'added' as change_type,
+           e->>'name' as path,
+           NULL as old_hash,
+           e->>'hash' as new_hash
+    FROM jsonb_array_elements(v_new_entries) e
+    WHERE NOT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(v_old_entries) oe
+        WHERE (oe->>'name') = (e->>'name')
+    );
+    
+    -- Deleted files
+    RETURN QUERY
+    SELECT 'deleted' as change_type,
+           e->>'name' as path,
+           e->>'hash' as old_hash,
+           NULL as new_hash
+    FROM jsonb_array_elements(v_old_entries) e
+    WHERE NOT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(v_new_entries) ne
+        WHERE (ne->>'name') = (e->>'name')
+    );
+    
+    -- Modified files
+    RETURN QUERY
+    SELECT 'modified' as change_type,
+           ne->>'name' as path,
+           oe->>'hash' as old_hash,
+           ne->>'hash' as new_hash
+    FROM jsonb_array_elements(v_old_entries) oe
+    JOIN jsonb_array_elements(v_new_entries) ne
+    ON (oe->>'name') = (ne->>'name')
+    WHERE (oe->>'hash') != (ne->>'hash');
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/schema/pgit-schema.sql =====
+-- Central schema definitions for PGit
+
+CREATE TABLE index_entries (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    path TEXT NOT NULL,
+    blob_hash TEXT NOT NULL,
+    mode TEXT NOT NULL DEFAULT '100644',
+    staged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (repo_id, blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    PRIMARY KEY (repo_id, path));
+
+-- ===== sql/functions/001-init.sql =====
+CREATE OR REPLACE FUNCTION init_repository(
+    p_name TEXT,
+    p_path TEXT
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_repo_id INTEGER;
+    v_initial_tree TEXT;
+    v_initial_commit TEXT;
+BEGIN
+    -- Create repository record
+    INSERT INTO pggit.repositories (name, path)
+    VALUES (p_name, p_path)
+    RETURNING id INTO v_repo_id;
+    
+    -- Create empty initial tree
+    v_initial_tree := create_tree(v_repo_id, '[]'::jsonb);
+    
+    -- Create initial commit
+    v_initial_commit := create_commit(
+        v_repo_id,
+        v_initial_tree,
+        NULL,
+        'system',
+        'Initial commit'
+    );
+    
+    -- Create master branch
+    PERFORM update_ref(v_repo_id, 'master', v_initial_commit);
+
+    -- Set HEAD to initial commit so subsequent commands work
+    PERFORM update_ref(v_repo_id, 'HEAD', v_initial_commit);
+    
+    RETURN v_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/002-add.sql =====
+
+-- Schema for staging area (index)
+
+-- Helper function to normalize file paths and prevent traversal
+CREATE OR REPLACE FUNCTION normalize_path(p_path TEXT)
+RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_parts TEXT[];
+    v_stack TEXT[] := ARRAY[]::TEXT[];
+    v_part TEXT;
+BEGIN
+    -- Reject absolute paths
+    IF p_path LIKE '/%' THEN
+        RAISE EXCEPTION 'Absolute paths are not allowed'
+            USING DETAIL = format('path: %s', p_path);
+    END IF;
+
+    -- Split and process path components
+    v_parts := regexp_split_to_array(p_path, '/+');
+    FOREACH v_part IN ARRAY v_parts LOOP
+        IF v_part = '' OR v_part = '.' THEN
+            CONTINUE;
+        ELSIF v_part = '..' THEN
+            -- Prevent traversing above repository root
+            IF array_length(v_stack, 1) IS NULL THEN
+                RAISE EXCEPTION 'Path traversal is not allowed'
+                    USING DETAIL = format('path: %s', p_path);
+            END IF;
+            v_stack := v_stack[1:array_length(v_stack,1)-1];
+        ELSE
+            v_stack := v_stack || v_part;
+        END IF;
+    END LOOP;
+
+    RETURN array_to_string(v_stack, '/');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Function to stage a file
+CREATE OR REPLACE FUNCTION stage_file(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_content BYTEA,
+    p_mode TEXT DEFAULT '100644'
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_blob_hash TEXT;
+    v_norm_path TEXT;
+BEGIN
+    -- Normalize and validate path
+    v_norm_path := normalize_path(p_path);
+
+    -- Create blob from file content
+    v_blob_hash := create_blob(p_repo_id, p_content);
+
+    -- Update index
+    INSERT INTO index_entries (repo_id, path, blob_hash, mode)
+    VALUES (p_repo_id, v_norm_path, v_blob_hash, p_mode)
+    ON CONFLICT (repo_id, path)
+    DO UPDATE SET blob_hash = v_blob_hash, path = EXCLUDED.path, staged_at = CURRENT_TIMESTAMP;
+
+    RETURN v_blob_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to unstage a file
+CREATE OR REPLACE FUNCTION unstage_file(
+    p_repo_id INTEGER,
+    p_path TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_norm_path TEXT;
+BEGIN
+    v_norm_path := normalize_path(p_path);
+
+    DELETE FROM index_entries
+    WHERE repo_id = p_repo_id AND path = v_norm_path;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/003-commit.sql =====
+-- Path: /sql/functions/003-commit.sql
+-- pg_git commit functions
+
+CREATE OR REPLACE FUNCTION pggit.create_tree_from_index(
+    p_repo_id INTEGER
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_entries JSONB;
+BEGIN
+    SELECT jsonb_agg(
+        jsonb_build_object(
+            'mode', mode,
+            'type', 'blob',
+            'hash', blob_hash,
+            'name', path
+        )
+    ) INTO v_entries
+    FROM (
+        SELECT mode, blob_hash, path
+        FROM index_entries
+        WHERE repo_id = p_repo_id
+        ORDER BY path
+    ) ordered_entries;
+
+    RETURN pggit.create_tree(p_repo_id, COALESCE(v_entries, '[]'::jsonb));
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.commit_index(
+    p_repo_id INTEGER,
+    p_author TEXT,
+    p_message TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_tree_hash TEXT;
+    v_parent_hash TEXT;
+    v_commit_hash TEXT;
+BEGIN
+    -- Get current HEAD
+    SELECT commit_hash INTO v_parent_hash
+    FROM pggit.refs
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+
+    -- Create tree from index
+    v_tree_hash := pggit.create_tree_from_index(p_repo_id);
+
+    -- Create commit
+    v_commit_hash := pggit.create_commit(
+        p_repo_id,
+        v_tree_hash,
+        v_parent_hash,
+        p_author,
+        p_message
+    );
+
+    -- Update HEAD and branch reference
+    UPDATE pggit.refs SET commit_hash = v_commit_hash WHERE repo_id = p_repo_id AND name = 'HEAD';
+    UPDATE pggit.refs
+    SET commit_hash = v_commit_hash
+    WHERE repo_id = p_repo_id
+      AND commit_hash = v_parent_hash
+      AND name <> 'HEAD';
+
+    -- Clear index
+    DELETE FROM index_entries WHERE repo_id = p_repo_id;
+
+    RETURN v_commit_hash;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/004-log.sql =====
+-- Path: /sql/functions/004-log.sql
+-- pg_git log functions
+
+CREATE OR REPLACE FUNCTION pggit.get_log(
+    p_repo_id INTEGER,
+    p_limit INTEGER DEFAULT NULL
+) RETURNS TABLE (
+    hash TEXT,
+    tree_hash TEXT,
+    parent_hash TEXT,
+    author TEXT,
+    message TEXT,
+    "timestamp" TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_head_commit TEXT;
+BEGIN
+    -- Get HEAD commit
+    SELECT commit_hash INTO v_head_commit
+    FROM pggit.refs
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+
+    RETURN QUERY
+    WITH RECURSIVE commit_log AS (
+        SELECT c.*
+        FROM pggit.commits c
+        WHERE c.repo_id = p_repo_id AND c.hash = v_head_commit
+
+        UNION ALL
+
+        SELECT c.*
+        FROM pggit.commits c
+        INNER JOIN commit_log cl ON c.repo_id = p_repo_id AND c.hash = cl.parent_hash
+    )
+    SELECT commit_log.hash, commit_log.tree_hash, commit_log.parent_hash,
+           commit_log.author, commit_log.message, commit_log."timestamp"
+    FROM commit_log
+    LIMIT p_limit;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Pretty format version with commit decoration
+CREATE OR REPLACE FUNCTION pggit.get_decorated_log(
+    p_repo_id INTEGER,
+    p_limit INTEGER DEFAULT NULL
+) RETURNS TABLE (
+    commit_line TEXT,
+    refs TEXT[]
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    WITH commit_refs AS (
+        SELECT c.hash,
+               c.message,
+               c.author,
+               c.timestamp,
+               array_agg(r.name) FILTER (WHERE r.name <> 'HEAD') as ref_names
+        FROM pggit.get_log(p_repo_id, p_limit) c
+        LEFT JOIN pggit.refs r ON r.repo_id = p_repo_id AND c.hash = r.commit_hash
+        GROUP BY c.hash, c.message, c.author, c.timestamp
+    )
+    SELECT 
+        format('commit %s%sAuthor: %s%sDate: %s%s%s%s',
+            substr(hash, 1, 8),
+            E'\n',
+            author,
+            E'\n',
+            "timestamp",
+            E'\n',
+            E'\n    ',
+            message
+        ) as commit_line,
+        ref_names
+    FROM commit_refs
+    ORDER BY "timestamp" DESC;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/005-status.sql =====
+-- Path: /sql/functions/005-status.sql
+-- pg_git status functions
+
+CREATE OR REPLACE FUNCTION pggit.get_status(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    path TEXT,
+    status TEXT,
+    staged BOOLEAN
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_head_commit TEXT;
+    v_head_tree TEXT;
+BEGIN
+    -- Get HEAD commit and tree
+    SELECT c.hash, c.tree_hash INTO v_head_commit, v_head_tree
+    FROM pggit.refs r
+    JOIN pggit.commits c ON r.repo_id = p_repo_id AND c.repo_id = r.repo_id AND r.commit_hash = c.hash
+    WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
+
+    RETURN QUERY
+    -- Staged changes
+    SELECT 
+        i.path,
+        CASE 
+            WHEN NOT EXISTS (
+                SELECT 1 FROM jsonb_array_elements(t.entries) e
+                WHERE e->>'name' = i.path
+            ) THEN 'new file'
+            WHEN i.blob_hash != (
+                SELECT e->>'hash'
+                FROM jsonb_array_elements(t.entries) e
+                WHERE e->>'name' = i.path
+            ) THEN 'modified'
+        END,
+        TRUE
+    FROM index_entries i
+    LEFT JOIN pggit.trees t ON t.repo_id = p_repo_id AND t.hash = v_head_tree
+    WHERE i.repo_id = p_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Pretty format version
+CREATE OR REPLACE FUNCTION pggit.get_formatted_status(
+    p_repo_id INTEGER
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_output TEXT;
+BEGIN
+    SELECT string_agg(
+        CASE 
+            WHEN staged THEN
+                format('  %s: %s', status, path)
+        END,
+        E'\n'
+    ) INTO v_output
+    FROM pggit.get_status(p_repo_id)
+    WHERE status IS NOT NULL;
+
+    RETURN format(
+        'Changes to be committed:%s%s',
+        E'\n',
+        COALESCE(v_output, '  (no changes)')
+    );
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/006-branch.sql =====
+-- Path: /sql/functions/006-branch.sql
+-- pg_git branch operations
+
+CREATE OR REPLACE FUNCTION pggit.create_branch(
+    p_repo_id INTEGER,
+    p_branch_name TEXT,
+    p_start_point TEXT DEFAULT NULL
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_commit_hash TEXT;
+BEGIN
+    -- Get commit hash from start point or HEAD
+    IF p_start_point IS NULL THEN
+        SELECT commit_hash INTO v_commit_hash
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+    ELSE
+        v_commit_hash := p_start_point;
+    END IF;
+
+    -- Create branch reference
+    INSERT INTO pggit.refs (repo_id, name, commit_hash)
+    VALUES (p_repo_id, p_branch_name, v_commit_hash);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.list_branches(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    name TEXT,
+    commit_hash TEXT,
+    is_current BOOLEAN
+) SET search_path = pggit, public AS $$
+SELECT 
+    r.name,
+    r.commit_hash,
+    r.commit_hash = head.commit_hash AS is_current
+FROM pggit.refs r
+CROSS JOIN (SELECT commit_hash FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD') head
+WHERE r.repo_id = p_repo_id AND r.name != 'HEAD'
+ORDER BY r.name;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.checkout_branch(
+    p_repo_id INTEGER,
+    p_branch_name TEXT,
+    p_create BOOLEAN DEFAULT FALSE
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_commit_hash TEXT;
+BEGIN
+    -- Get branch commit
+    SELECT commit_hash INTO v_commit_hash
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_branch_name;
+    
+    IF NOT FOUND AND p_create THEN
+        -- Create new branch from HEAD
+        SELECT commit_hash INTO v_commit_hash
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+        
+        INSERT INTO pggit.refs (repo_id, name, commit_hash)
+        VALUES (p_repo_id, p_branch_name, v_commit_hash);
+    ELSIF NOT FOUND THEN
+        RAISE EXCEPTION 'Branch % does not exist', p_branch_name;
+    END IF;
+
+    -- Update HEAD
+    UPDATE pggit.refs SET commit_hash = v_commit_hash
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+
+    RETURN v_commit_hash;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/007-merge.sql =====
+-- Path: /sql/functions/007-merge.sql
+-- pg_git merge operations
+
+-- Most recent common ancestor of two commits. Commit hashes are globally unique,
+-- so the repository is implied by the commits themselves. A recursive CTE allows
+-- only one non-recursive and one recursive term, so each ancestor walk is its own
+-- recursive CTE and the two are intersected.
+CREATE OR REPLACE FUNCTION pggit.find_merge_base(
+    p_commit1 TEXT,
+    p_commit2 TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+WITH RECURSIVE ancestors1 AS (
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
+    WHERE hash = p_commit1
+    UNION ALL
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestors1 a ON a.repo_id = c.repo_id AND a.parent_hash = c.hash
+),
+ancestors2 AS (
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
+    WHERE hash = p_commit2
+    UNION ALL
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestors2 a ON a.repo_id = c.repo_id AND a.parent_hash = c.hash
+)
+SELECT c.hash
+FROM ancestors1 a1
+JOIN ancestors2 a2 ON a1.repo_id = a2.repo_id AND a1.hash = a2.hash
+JOIN pggit.commits c ON c.repo_id = a1.repo_id AND c.hash = a1.hash
+ORDER BY c.timestamp DESC
+LIMIT 1;
+$$ LANGUAGE sql;
+
+-- True when p_source is an ancestor of p_target, i.e. p_target can be
+-- fast-forwarded onto p_source's history (p_source is reachable from p_target).
+CREATE OR REPLACE FUNCTION pggit.can_fast_forward(
+    p_source TEXT,
+    p_target TEXT
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
+WITH RECURSIVE ancestor_chain AS (
+    SELECT hash, parent_hash, repo_id
+    FROM pggit.commits
+    WHERE hash = p_target
+    UNION ALL
+    SELECT c.hash, c.parent_hash, c.repo_id
+    FROM pggit.commits c
+    JOIN ancestor_chain ac ON ac.repo_id = c.repo_id AND ac.parent_hash = c.hash
+)
+SELECT EXISTS (
+    SELECT 1 FROM ancestor_chain WHERE hash = p_source
+);
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.merge_branches(
+    p_repo_id INTEGER,
+    p_source_branch TEXT,
+    p_target_branch TEXT DEFAULT 'HEAD'
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_source_commit TEXT;
+    v_target_commit TEXT;
+BEGIN
+    -- Resolve both branches, failing clearly if either is missing.
+    SELECT commit_hash INTO v_source_commit
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_source_branch;
+    IF v_source_commit IS NULL THEN
+        RAISE EXCEPTION 'Branch % does not exist', p_source_branch;
+    END IF;
+
+    SELECT commit_hash INTO v_target_commit
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_target_branch;
+    IF v_target_commit IS NULL THEN
+        RAISE EXCEPTION 'Branch % does not exist', p_target_branch;
+    END IF;
+
+    -- Fast-forward is possible when the target commit is an ancestor of the
+    -- source commit; advance the target ref to the source commit.
+    IF pggit.can_fast_forward(v_target_commit, v_source_commit) THEN
+        UPDATE pggit.refs
+        SET commit_hash = v_source_commit
+        WHERE repo_id = p_repo_id AND name = p_target_branch;
+
+        RETURN v_source_commit;
+    END IF;
+
+    -- For now, only support fast-forward merges
+    RAISE EXCEPTION 'Only fast-forward merges are currently supported';
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/008-diff.sql =====
+-- Path: /sql/functions/008-diff.sql
+-- pg_git diff operations
+
+CREATE OR REPLACE FUNCTION pggit.diff_blobs(
+    p_old_hash TEXT,
+    p_new_hash TEXT
+) RETURNS TABLE (
+    line_type TEXT,
+    line_content TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_old_content TEXT;
+    v_new_content TEXT;
+BEGIN
+    -- Get content from pggit.blobs
+    SELECT encode(content, 'escape') INTO v_old_content
+    FROM pggit.blobs WHERE hash = p_old_hash;
+    
+    SELECT encode(content, 'escape') INTO v_new_content
+    FROM pggit.blobs WHERE hash = p_new_hash;
+    
+    RETURN QUERY
+    SELECT *
+    FROM pggit.diff_text(v_old_content, v_new_content);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.diff_text(
+    p_old_text TEXT,
+    p_new_text TEXT
+) RETURNS TABLE (
+    line_type TEXT,
+    line_content TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    -- Split texts into arrays with line numbers using ordinality
+    RETURN QUERY
+    WITH old_lines AS (
+        SELECT line, line_num
+        FROM unnest(string_to_array(p_old_text, E'\n')) WITH ORDINALITY AS t(line, line_num)
+    ),
+    new_lines AS (
+        SELECT line, line_num
+        FROM unnest(string_to_array(p_new_text, E'\n')) WITH ORDINALITY AS t(line, line_num)
+    )
+    -- Simple line-by-line diff preserving line order. Columns are qualified with
+    -- the subquery alias to avoid ambiguity with the RETURNS TABLE OUT columns.
+    SELECT d.line_type, d.line_content
+    FROM (
+        SELECT line_num, '-' AS line_type, old_lines.line AS line_content
+        FROM old_lines
+        LEFT JOIN new_lines USING (line_num, line)
+        WHERE new_lines.line IS NULL
+        UNION ALL
+        SELECT line_num, '+' AS line_type, new_lines.line AS line_content
+        FROM new_lines
+        LEFT JOIN old_lines USING (line_num, line)
+        WHERE old_lines.line IS NULL
+        UNION ALL
+        SELECT line_num, ' ' AS line_type, old_lines.line AS line_content
+        FROM old_lines
+        JOIN new_lines USING (line_num, line)
+    ) d
+    ORDER BY d.line_num, CASE d.line_type WHEN '-' THEN 1 WHEN '+' THEN 2 ELSE 3 END;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.diff_commits(
+    p_old_commit TEXT,
+    p_new_commit TEXT
+) RETURNS TABLE (
+    path TEXT,
+    change_type TEXT,
+    diff_content TEXT[]
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_repo_id INTEGER;
+    v_old_tree TEXT;
+    v_new_tree TEXT;
+BEGIN
+    -- Get tree hashes
+    SELECT repo_id, tree_hash INTO v_repo_id, v_old_tree
+    FROM pggit.commits WHERE hash = p_old_commit;
+
+    IF v_repo_id IS NULL THEN
+        SELECT repo_id INTO v_repo_id
+        FROM pggit.commits WHERE hash = p_new_commit;
+    END IF;
+
+    SELECT tree_hash INTO v_new_tree
+    FROM pggit.commits WHERE hash = p_new_commit AND repo_id = v_repo_id;
+
+    RETURN QUERY
+    SELECT
+        d.path,
+        d.change_type,
+        CASE 
+            WHEN d.change_type = 'modified' THEN
+                ARRAY(
+                    SELECT line_type || line_content
+                    FROM pggit.diff_blobs(d.old_hash, d.new_hash)
+                )
+            ELSE
+                ARRAY[]::TEXT[]
+        END as diff_content
+    FROM pggit.diff_trees(v_repo_id, v_old_tree, v_new_tree) d;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/009-reset.sql =====
+-- Path: /sql/functions/009-reset.sql
+-- pg_git reset operations
+
+CREATE OR REPLACE FUNCTION pggit.reset_soft(
+    p_repo_id INTEGER,
+    p_commit TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    -- Move HEAD to specified commit
+    UPDATE pggit.refs
+    SET commit_hash = p_commit
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.reset_mixed(
+    p_repo_id INTEGER,
+    p_commit TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    -- Move HEAD and clear index
+    PERFORM pggit.reset_soft(p_repo_id, p_commit);
+    DELETE FROM index_entries WHERE repo_id = p_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.reset_file(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_commit TEXT DEFAULT 'HEAD'
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_tree_hash TEXT;
+    v_blob_hash TEXT;
+BEGIN
+    -- Get tree from commit
+    SELECT tree_hash INTO v_tree_hash
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_commit;
+    
+    -- Get blob hash from tree
+    SELECT (e->>'hash')::TEXT INTO v_blob_hash
+    FROM pggit.trees t,
+    jsonb_array_elements(t.entries) e
+    WHERE t.repo_id = p_repo_id AND t.hash = v_tree_hash
+    AND e->>'name' = p_path;
+    
+    IF v_blob_hash IS NULL THEN
+        -- File doesn't exist in commit, remove from index
+        DELETE FROM index_entries 
+        WHERE repo_id = p_repo_id AND path = p_path;
+    ELSE
+        -- Update index with blob from commit
+        INSERT INTO index_entries (repo_id, path, blob_hash)
+        VALUES (p_repo_id, p_path, v_blob_hash)
+        ON CONFLICT (repo_id, path) 
+        DO UPDATE SET blob_hash = v_blob_hash;
+    END IF;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/010-tag.sql =====
+-- Path: /sql/functions/010-tag.sql
+-- pg_git tag operations
+
+CREATE TABLE pggit.tags (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    name TEXT NOT NULL,
+    target_hash TEXT NOT NULL,
+    tagger TEXT NOT NULL,
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, name)
+);
+
+CREATE OR REPLACE FUNCTION pggit.create_tag(
+    p_repo_id INTEGER,
+    p_name TEXT,
+    p_target TEXT DEFAULT 'HEAD',
+    p_tagger TEXT DEFAULT current_user,
+    p_message TEXT DEFAULT NULL
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_target_hash TEXT;
+BEGIN
+    -- Resolve target to commit hash
+    IF p_target = 'HEAD' THEN
+        SELECT commit_hash INTO v_target_hash
+        FROM pggit.refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+    ELSE
+        v_target_hash := p_target;
+    END IF;
+
+    INSERT INTO pggit.tags (repo_id, name, target_hash, tagger, message)
+    VALUES (p_repo_id, p_name, v_target_hash, p_tagger, p_message);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.list_tags(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    name TEXT,
+    target_hash TEXT,
+    tagger TEXT,
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
+    SELECT name, target_hash, tagger, message, created_at
+    FROM pggit.tags
+    WHERE repo_id = p_repo_id
+    ORDER BY created_at DESC;$$ LANGUAGE sql;
+
+-- ===== sql/functions/011-remote.sql =====
+-- Path: /sql/functions/011-remote.sql
+-- pg_git remote operations
+
+CREATE TABLE pggit.remotes (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, name)
+);
+
+CREATE TABLE pggit.remote_refs (
+    repo_id INTEGER,
+    remote_name TEXT,
+    ref_name TEXT NOT NULL,
+    commit_hash TEXT NOT NULL,
+    last_fetch TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, remote_name, ref_name),
+    FOREIGN KEY (repo_id, remote_name) REFERENCES pggit.remotes(repo_id, name)
+);
+
+COMMENT ON TABLE pggit.remote_refs IS
+    'Source of truth for fetched remote branch tips. fetch_remote materializes these into refs as <remote>/<branch> tracking refs.';
+
+CREATE OR REPLACE FUNCTION pggit.add_remote(
+    p_repo_id INTEGER,
+    p_name TEXT,
+    p_url TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.remotes (repo_id, name, url)
+    VALUES (p_repo_id, p_name, p_url);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.fetch_remote(
+    p_repo_id INTEGER,
+    p_remote_name TEXT
+) RETURNS TABLE (
+    ref_name TEXT,
+    old_hash TEXT,
+    new_hash TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_remote_url TEXT;
+BEGIN
+    -- Get remote URL
+    SELECT url INTO v_remote_url
+    FROM pggit.remotes
+    WHERE repo_id = p_repo_id AND name = p_remote_name;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Remote % does not exist for repo %', p_remote_name, p_repo_id;
+    END IF;
+
+    -- Source of truth: pggit.remote_refs stores fetched remote branch tips.
+    -- Materialized remote-tracking refs in refs are derived as <remote>/<branch>.
+    RETURN QUERY
+    WITH tracking AS (
+        SELECT
+            rr.ref_name,
+            (p_remote_name || '/' || rr.ref_name) AS tracking_ref,
+            rr.commit_hash AS remote_hash
+        FROM pggit.remote_refs rr
+        WHERE rr.repo_id = p_repo_id
+          AND rr.remote_name = p_remote_name
+    ),
+    existing AS (
+        SELECT name, commit_hash
+        FROM refs
+        WHERE repo_id = p_repo_id
+    ),
+    upserted AS (
+        INSERT INTO refs (repo_id, name, commit_hash)
+        SELECT p_repo_id, tracking_ref, remote_hash
+        FROM tracking
+        ON CONFLICT (repo_id, name)
+        DO UPDATE SET commit_hash = EXCLUDED.commit_hash
+        RETURNING name, commit_hash
+    )
+    SELECT
+        t.ref_name,
+        e.commit_hash AS old_hash,
+        u.commit_hash AS new_hash
+    FROM upserted u
+    JOIN tracking t ON t.tracking_ref = u.name
+    LEFT JOIN existing e ON e.name = t.tracking_ref;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.push(
+    p_repo_id INTEGER,
+    p_remote_name TEXT,
+    p_ref_name TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_remote_url TEXT;
+    v_commit_hash TEXT;
+BEGIN
+    -- Get remote URL
+    SELECT url INTO v_remote_url
+    FROM pggit.remotes
+    WHERE repo_id = p_repo_id AND name = p_remote_name;
+
+    -- Get local ref
+    SELECT commit_hash INTO v_commit_hash
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_ref_name;
+
+    -- In a real implementation, this would:
+    -- 1. Connect to remote database
+    -- 2. Push missing objects
+    -- 3. Update remote ref
+    RAISE NOTICE 'Would push % to %/%', v_commit_hash, v_remote_url, p_ref_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.pull(
+    p_repo_id INTEGER,
+    p_remote_name TEXT,
+    p_ref_name TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_tracking_ref TEXT;
+BEGIN
+    -- Fetch from remote
+    PERFORM pggit.fetch_remote(p_repo_id, p_remote_name);
+
+    v_tracking_ref := p_remote_name || '/' || p_ref_name;
+
+    IF NOT EXISTS (
+        SELECT 1
+        FROM refs
+        WHERE repo_id = p_repo_id
+          AND name = v_tracking_ref
+    ) THEN
+        RAISE EXCEPTION 'Remote-tracking ref % does not exist for repo %', v_tracking_ref, p_repo_id;
+    END IF;
+
+    -- Merge verified remote-tracking ref into local branch
+    RETURN pggit.merge_branches(
+        p_repo_id,
+        v_tracking_ref,
+        p_ref_name
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.clone(
+    p_url TEXT,
+    p_name TEXT,
+    p_path TEXT
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_repo_id INTEGER;
+BEGIN
+    -- Create new repo
+    v_repo_id := pggit.init_repository(p_name, p_path);
+    
+    -- Add remote
+    PERFORM pggit.add_remote(v_repo_id, 'origin', p_url);
+    
+    -- Fetch everything
+    PERFORM pggit.fetch_remote(v_repo_id, 'origin');
+    
+    -- Checkout main branch
+    PERFORM pggit.checkout_branch(v_repo_id, 'main', TRUE);
+    
+    RETURN v_repo_id;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/012-migrations.sql =====
+-- Path: /sql/functions/012-migrations.sql
+-- pg_git schema migrations
+
+CREATE TABLE pggit.schema_migrations (
+    version INTEGER PRIMARY KEY,
+    applied_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION pggit.get_current_schema_version()
+RETURNS INTEGER SET search_path = pggit, public AS $$
+    SELECT COALESCE(MAX(version), 0) FROM pggit.schema_migrations;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.run_migration(
+    p_version INTEGER,
+    p_up TEXT,
+    p_down TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    IF p_version > pggit.get_current_schema_version() THEN
+        EXECUTE p_up;
+        INSERT INTO pggit.schema_migrations (version) VALUES (p_version);
+    END IF;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/013-merge-conflicts.sql =====
+-- Path: /sql/functions/013-merge-conflicts.sql
+-- pg_git merge conflict resolution
+
+CREATE TABLE pggit.merge_conflicts (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    path TEXT NOT NULL,
+    our_blob_hash TEXT,
+    their_blob_hash TEXT,
+    base_blob_hash TEXT,
+    resolution_blob_hash TEXT,
+    status TEXT CHECK (status IN ('unresolved', 'resolved', 'ignored')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, path),
+    FOREIGN KEY (repo_id, our_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, their_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, base_blob_hash) REFERENCES pggit.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
+    p_repo_id INTEGER,
+    p_our_commit TEXT,
+    p_their_commit TEXT
+) RETURNS TABLE (
+    path TEXT,
+    conflict_type TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_base_commit TEXT;
+BEGIN
+    -- Find merge base
+    v_base_commit := pggit.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
+    
+    RETURN QUERY
+    WITH our_files AS (
+        SELECT path, blob_hash
+        FROM pggit.get_tree_files(p_our_commit)
+    ),
+    their_files AS (
+        SELECT path, blob_hash
+        FROM pggit.get_tree_files(p_their_commit)
+    ),
+    base_files AS (
+        SELECT path, blob_hash
+        FROM pggit.get_tree_files(v_base_commit)
+    )
+    SELECT DISTINCT f.path,
+           CASE
+               WHEN o.blob_hash != t.blob_hash 
+                    AND b.blob_hash IS NOT NULL THEN 'content'
+               WHEN o.blob_hash IS NULL 
+                    AND t.blob_hash IS NOT NULL THEN 'deleted_modified'
+               ELSE 'add_add'
+           END as conflict_type
+    FROM (SELECT path FROM our_files 
+          UNION SELECT path FROM their_files) f
+    LEFT JOIN our_files o ON f.path = o.path
+    LEFT JOIN their_files t ON f.path = t.path
+    LEFT JOIN base_files b ON f.path = b.path
+    WHERE (o.blob_hash != t.blob_hash OR o.blob_hash IS NULL OR t.blob_hash IS NULL)
+    AND NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/functions/014-https.sql =====
+-- Path: /sql/functions/014-https.sql
+-- pg_git HTTPS transport
+
+CREATE TABLE pggit.credentials (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
+    host TEXT NOT NULL,
+    username TEXT NOT NULL,
+    password BYTEA NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, host)
+);
+
+CREATE OR REPLACE FUNCTION pggit.store_credentials(
+    p_repo_id INTEGER,
+    p_host TEXT,
+    p_username TEXT,
+    p_password TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_key TEXT := current_setting('pggit.credential_key', true);
+BEGIN
+    INSERT INTO pggit.credentials (repo_id, host, username, password)
+    VALUES (
+        p_repo_id,
+        p_host,
+        p_username,
+        pgp_sym_encrypt(p_password, coalesce(v_key, 'pg_git_default_key'))
+    )
+    ON CONFLICT (repo_id, host) DO UPDATE
+    SET username = EXCLUDED.username,
+        password = pgp_sym_encrypt(p_password, coalesce(v_key, 'pg_git_default_key'));
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.http_fetch(
+    p_repo_id INTEGER,
+    p_url TEXT
+) RETURNS BYTEA SET search_path = pggit, public AS $$import base64
+import ssl
+from urllib.parse import urlparse
+import urllib.request
+import urllib.error
+
+host = urlparse(p_url).hostname
+key = plpy.execute("SELECT current_setting('pggit.credential_key', true) AS k")[0]['k'] or 'pg_git_default_key'
+# Parameterized queries require a prepared plan; plpy.execute(query, x) treats x
+# as a row limit, not bind parameters.
+cred_plan = plpy.prepare(
+    "SELECT username, pgp_sym_decrypt(password, $1) AS pw FROM pggit.credentials WHERE repo_id = $2 AND host = $3",
+    ["text", "integer", "text"]
+)
+cred = plpy.execute(cred_plan, [key, p_repo_id, host])
+
+context = ssl.create_default_context()
+
+username = None
+password = None
+if len(cred) > 0:
+    username = cred[0]['username']
+    password = cred[0]['pw']
+
+req = urllib.request.Request(p_url)
+if username:
+    token = f"{username}:{password}".encode('utf-8')
+    req.add_header('Authorization', 'Basic ' + base64.b64encode(token).decode('ascii'))
+
+try:
+    with urllib.request.urlopen(req, context=context, timeout=10) as resp:
+        data = resp.read()
+except urllib.error.HTTPError as e:
+    raise plpy.Error(f"Failed to fetch {p_url}: HTTP {e.code} {e.reason}")
+except urllib.error.URLError as e:
+    raise plpy.Error(f"Failed to fetch {p_url}: {e.reason}")
+
+return data
+$$ LANGUAGE plpython3u;
+
+-- ===== sql/functions/015-admin.sql =====
+-- Path: /sql/functions/015-admin.sql
+-- pg_git admin functions
+
+CREATE OR REPLACE FUNCTION pggit.gc(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    object_type TEXT,
+    objects_removed INTEGER,
+    space_reclaimed BIGINT
+) SET search_path = pggit, public AS $$
+BEGIN
+    -- Ensure temporary table does not exist from prior runs
+    DROP TABLE IF EXISTS tmp_reachable_objects;
+
+    -- Collect all reachable objects into a temporary table
+    CREATE TEMP TABLE tmp_reachable_objects(hash TEXT PRIMARY KEY) ON COMMIT DROP;
+
+    -- PostgreSQL recursive CTEs allow only a single self-reference in the
+    -- recursive term, so the different edge types (commit->parent, commit->tree,
+    -- tree->entries) are expanded in one LATERAL branch off the working row.
+    WITH RECURSIVE reachable(object_type, hash) AS (
+        -- Start from pggit.refs
+        SELECT 'commit'::TEXT, commit_hash FROM pggit.refs WHERE repo_id = p_repo_id
+        UNION
+        SELECT nxt.object_type, nxt.hash
+        FROM reachable r
+        CROSS JOIN LATERAL (
+            -- Walk parent commits
+            SELECT 'commit'::TEXT AS object_type, c.parent_hash AS hash
+            FROM pggit.commits c
+            WHERE r.object_type = 'commit' AND c.repo_id = p_repo_id
+              AND c.hash = r.hash AND c.parent_hash IS NOT NULL
+            UNION ALL
+            -- Commits reference trees
+            SELECT 'tree'::TEXT, c.tree_hash
+            FROM pggit.commits c
+            WHERE r.object_type = 'commit' AND c.repo_id = p_repo_id AND c.hash = r.hash
+            UNION ALL
+            -- Trees reference blobs and subtrees
+            SELECT (e->>'type')::TEXT, e->>'hash'
+            FROM pggit.trees t
+            CROSS JOIN LATERAL jsonb_array_elements(t.entries) AS e
+            WHERE r.object_type = 'tree' AND t.repo_id = p_repo_id AND t.hash = r.hash
+        ) nxt
+        WHERE nxt.hash IS NOT NULL
+    )
+    INSERT INTO tmp_reachable_objects
+    SELECT DISTINCT hash FROM reachable;
+
+    -- Remove unreachable objects
+    RETURN QUERY
+    WITH deleted_blobs AS (
+        DELETE FROM pggit.blobs b
+        WHERE b.repo_id = p_repo_id AND NOT EXISTS (
+            SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = b.hash
+        )
+        RETURNING octet_length(content) AS size
+    ), deleted_trees AS (
+        DELETE FROM pggit.trees t
+        WHERE t.repo_id = p_repo_id AND NOT EXISTS (
+            SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = t.hash
+        )
+        RETURNING octet_length(entries::TEXT) AS size
+    ), deleted_commits AS (
+        DELETE FROM pggit.commits c
+        WHERE c.repo_id = p_repo_id AND NOT EXISTS (
+            SELECT 1 FROM tmp_reachable_objects r WHERE r.hash = c.hash
+        )
+        RETURNING octet_length(message) AS size
+    )
+    SELECT 'blobs'::TEXT,
+           count(*)::INTEGER,
+           COALESCE(sum(size),0)::BIGINT FROM deleted_blobs
+    UNION ALL
+    SELECT 'trees'::TEXT,
+           count(*)::INTEGER,
+           COALESCE(sum(size),0)::BIGINT FROM deleted_trees
+    UNION ALL
+    SELECT 'commits'::TEXT,
+           count(*)::INTEGER,
+           COALESCE(sum(size),0)::BIGINT FROM deleted_commits;
+
+    -- Explicitly drop temporary table
+    DROP TABLE IF EXISTS tmp_reachable_objects;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.verify_integrity(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    check_type TEXT,
+    status TEXT,
+    details TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    -- Check dangling pggit.commits
+    RETURN QUERY
+    SELECT 'dangling_commits'::TEXT,
+           CASE WHEN count(*) = 0 THEN 'ok' ELSE 'warning' END,
+           count(*) || ' dangling pggit.commits found'
+    FROM pggit.commits c
+    WHERE c.repo_id = p_repo_id
+      AND NOT EXISTS (SELECT 1 FROM pggit.refs r WHERE r.repo_id = p_repo_id AND r.commit_hash = c.hash);
+
+    -- Check broken parent links
+    RETURN QUERY
+    SELECT 'broken_parents'::TEXT,
+           CASE WHEN count(*) = 0 THEN 'ok' ELSE 'error' END,
+           count(*) || ' pggit.commits with invalid parent references'
+    FROM pggit.commits c
+    WHERE c.repo_id = p_repo_id
+      AND c.parent_hash IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM pggit.commits p WHERE p.repo_id = p_repo_id AND p.hash = c.parent_hash);
+    
+    -- Check broken tree references
+    RETURN QUERY
+    SELECT 'broken_trees'::TEXT,
+           CASE WHEN count(*) = 0 THEN 'ok' ELSE 'error' END,
+           count(*) || ' pggit.commits with invalid tree references'
+    FROM pggit.commits c
+    WHERE c.repo_id = p_repo_id
+      AND NOT EXISTS (SELECT 1 FROM pggit.trees t WHERE t.repo_id = p_repo_id AND t.hash = c.tree_hash);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.optimize_indexes(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    table_name TEXT,
+    index_name TEXT,
+    operation TEXT,
+    success BOOLEAN
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_table TEXT;
+    v_index TEXT;
+BEGIN
+    -- Reindex each index in the pggit schema, capturing per-index success.
+    -- Results are emitted with RETURN NEXT (no temp table) so the function makes
+    -- no catalog writes of its own and can run in a read-only transaction.
+    FOR v_table, v_index IN
+        SELECT t.tablename::TEXT,
+               i.indexname::TEXT
+        FROM pg_tables t
+        JOIN pg_indexes i ON i.schemaname = t.schemaname AND i.tablename = t.tablename
+        WHERE t.schemaname = 'pggit'
+        ORDER BY t.tablename, i.indexname
+    LOOP
+        table_name := v_table;
+        index_name := v_index;
+        operation := 'REINDEX';
+        BEGIN
+            EXECUTE format('REINDEX INDEX pggit.%I', v_index);
+            success := TRUE;
+        EXCEPTION WHEN OTHERS THEN
+            RAISE NOTICE 'Reindex failed for %: %', v_index, SQLERRM;
+            success := FALSE;
+        END;
+        RETURN NEXT;
+    END LOOP;
+END;$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-advanced-commands.sql =====
+-- Path: /sql/functions/016-advanced-commands.sql
+-- Additional Git commands implementation
+
+-- Notes support
+CREATE TABLE pggit.notes (
+    repo_id INTEGER REFERENCES repositories(id),
+    object_hash TEXT NOT NULL,
+    note TEXT NOT NULL,
+    author TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, object_hash)
+);
+
+-- Stash support
+CREATE TABLE pggit.stash (
+    repo_id INTEGER REFERENCES repositories(id),
+    stash_id SERIAL,
+    tree_hash TEXT NOT NULL,
+    parent_hash TEXT,
+    message TEXT NOT NULL,
+    author TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, stash_id),
+    FOREIGN KEY (repo_id, tree_hash) REFERENCES pggit.trees(repo_id, hash),
+    FOREIGN KEY (repo_id, parent_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+-- Worktree support
+CREATE TABLE pggit.worktrees (
+    repo_id INTEGER REFERENCES repositories(id),
+    path TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    commit_hash TEXT NOT NULL,
+    locked BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, path),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+-- Command implementations
+
+CREATE OR REPLACE FUNCTION pggit.add_note(
+    p_repo_id INTEGER,
+    p_object_hash TEXT,
+    p_note TEXT,
+    p_author TEXT DEFAULT current_user
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.notes (repo_id, object_hash, note, author)
+    VALUES (p_repo_id, p_object_hash, p_note, p_author)
+    ON CONFLICT (repo_id, object_hash) 
+    DO UPDATE SET note = p_note, author = p_author;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.stash_save(
+    p_repo_id INTEGER,
+    p_message TEXT DEFAULT '',
+    p_author TEXT DEFAULT current_user
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_tree_hash TEXT;
+    v_stash_id INTEGER;
+BEGIN
+    -- Create tree from current index
+    v_tree_hash := pggit.create_tree_from_index(p_repo_id);
+    
+    INSERT INTO pggit.stash (repo_id, tree_hash, parent_hash, message, author)
+    VALUES (p_repo_id, v_tree_hash, 
+            (SELECT commit_hash FROM refs WHERE name = 'HEAD'),
+            p_message, p_author)
+    RETURNING stash_id INTO v_stash_id;
+    
+    -- Clear index
+    DELETE FROM index_entries WHERE repo_id = p_repo_id;
+    
+    RETURN v_stash_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.stash_pop(
+    p_repo_id INTEGER,
+    p_stash_id INTEGER DEFAULT NULL
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_stash RECORD;
+BEGIN
+    -- Get most recent stash if no id provided
+    IF p_stash_id IS NULL THEN
+        SELECT * INTO v_stash
+        FROM pggit.stash
+        WHERE repo_id = p_repo_id
+        ORDER BY stash_id DESC
+        LIMIT 1;
+    ELSE
+        SELECT * INTO v_stash
+        FROM pggit.stash
+        WHERE repo_id = p_repo_id AND stash_id = p_stash_id;
+    END IF;
+    
+    -- Apply stash to index
+    INSERT INTO index_entries (repo_id, path, blob_hash)
+    SELECT p_repo_id, e->>'name', e->>'hash'
+    FROM trees, jsonb_array_elements(entries) e
+    WHERE hash = v_stash.tree_hash;
+    
+    -- Remove stash
+    DELETE FROM pggit.stash
+    WHERE repo_id = p_repo_id AND stash_id = v_stash.stash_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.add_worktree(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_branch TEXT,
+    p_create_branch BOOLEAN DEFAULT FALSE
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_commit_hash TEXT;
+BEGIN
+    -- Get or create branch
+    IF p_create_branch THEN
+        PERFORM pggit.create_branch(p_repo_id, p_branch);
+    END IF;
+    
+    SELECT commit_hash INTO v_commit_hash
+    FROM refs WHERE name = p_branch;
+    
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'Branch % not found', p_branch;
+    END IF;
+    
+    INSERT INTO pggit.worktrees (repo_id, path, branch, commit_hash)
+    VALUES (p_repo_id, p_path, p_branch, v_commit_hash);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Blame implementation
+CREATE OR REPLACE FUNCTION pggit.blame(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_commit TEXT DEFAULT 'HEAD'
+) RETURNS TABLE (
+    line_number INTEGER,
+    commit_hash TEXT,
+    author TEXT,
+    "timestamp" TIMESTAMP WITH TIME ZONE,
+    line_content TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_commit_hash TEXT;
+    v_blob_hash TEXT;
+BEGIN
+    -- Resolve commit (qualify commit_hash to avoid clash with the OUT column)
+    IF p_commit = 'HEAD' THEN
+        SELECT r.commit_hash INTO v_commit_hash
+        FROM refs r WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
+    ELSE
+        v_commit_hash := p_commit;
+    END IF;
+    
+    -- Get blob hash for file
+    SELECT e->>'hash' INTO v_blob_hash
+    FROM commits c
+    JOIN trees t ON c.tree_hash = t.hash,
+    jsonb_array_elements(t.entries) e
+    WHERE c.hash = v_commit_hash
+    AND e->>'name' = p_path;
+    
+    -- Return blame data
+    RETURN QUERY
+    WITH RECURSIVE file_history AS (
+        SELECT c.hash, c.author, c.timestamp,
+               b.content,
+               generate_subscripts(regexp_split_to_array(encode(b.content, 'escape'), E'\n'), 1) as line_number,
+               regexp_split_to_array(encode(b.content, 'escape'), E'\n') as lines
+        FROM commits c
+        JOIN trees t ON c.tree_hash = t.hash,
+        jsonb_array_elements(t.entries) e
+        JOIN blobs b ON e->>'hash' = b.hash
+        WHERE c.hash = v_commit_hash
+        AND e->>'name' = p_path
+    )
+    SELECT h.line_number,
+           h.hash,
+           h.author,
+           h.timestamp,
+           h.lines[h.line_number]
+    FROM file_history h
+    ORDER BY h.line_number;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-archive.sql =====
+-- Path: /sql/functions/019-archive.sql
+-- Archive functionality
+
+CREATE OR REPLACE FUNCTION pggit.create_archive(
+    p_repo_id INTEGER,
+    p_tree_ish TEXT DEFAULT 'HEAD',
+    p_format TEXT DEFAULT 'tar'
+) RETURNS BYTEA SET search_path = pggit, public AS $$
+DECLARE
+    v_tree_hash TEXT;
+    v_archive BYTEA;
+    v_header BYTEA;
+    v_footer BYTEA;
+BEGIN
+    -- Resolve tree-ish to tree hash
+    IF p_tree_ish = 'HEAD' THEN
+        SELECT tree_hash INTO v_tree_hash
+        FROM commits c
+        JOIN refs r ON c.hash = r.commit_hash
+        WHERE r.name = 'HEAD';
+    ELSE
+        SELECT tree_hash INTO v_tree_hash
+        FROM commits
+        WHERE hash = p_tree_ish;
+    END IF;
+
+    -- Initialize archive based on format
+    CASE p_format
+        WHEN 'tar' THEN
+            v_header := '\x00'::BYTEA; -- tar header
+            v_footer := '\x00'::BYTEA; -- tar footer
+        WHEN 'zip' THEN
+            v_header := '\x50\x4B\x03\x04'::BYTEA; -- ZIP header
+            v_footer := '\x50\x4B\x05\x06'::BYTEA; -- ZIP footer
+    END CASE;
+
+    -- Build archive content
+    WITH RECURSIVE tree_files AS (
+        SELECT e->>'name' as path,
+               e->>'hash' as hash,
+               e->>'mode' as mode
+        FROM trees,
+        jsonb_array_elements(entries) e
+        WHERE hash = v_tree_hash
+        
+        UNION ALL
+        
+        SELECT tf.path || '/' || e->>'name',
+               e->>'hash',
+               e->>'mode'
+        FROM tree_files tf
+        JOIN trees t ON tf.hash = t.hash,
+        jsonb_array_elements(t.entries) e
+        WHERE e->>'type' = 'tree'
+    )
+    SELECT v_header || 
+           string_agg(
+               CASE p_format
+                   WHEN 'tar' THEN
+                       -- tar file header (simplified)
+                       convert_to(rpad(path, 100, '\0'), 'UTF8') ||
+                       convert_to(rpad(mode, 8, '\0'), 'UTF8') ||
+                       content
+                   WHEN 'zip' THEN
+                       -- zip file header (simplified)
+                       convert_to(path || '\n', 'UTF8') ||
+                       content
+               END,
+               ''::BYTEA
+           ) || v_footer
+    INTO v_archive
+    FROM tree_files tf
+    JOIN blobs b ON tf.hash = b.hash;
+
+    RETURN v_archive;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-bundle.sql =====
+-- Path: /sql/functions/032-bundle.sql
+-- Bundle repository data for offline transfer
+
+CREATE TABLE pggit.bundles (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER REFERENCES repositories(id),
+    name TEXT NOT NULL,
+    description TEXT,
+    prerequisites TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "references" TEXT[] NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION pggit.create_bundle(
+    p_repo_id INTEGER,
+    p_name TEXT,
+    p_refs TEXT[],
+    p_description TEXT DEFAULT NULL
+) RETURNS BYTEA SET search_path = pggit, public AS $$
+DECLARE
+    v_bundle_data BYTEA;
+    v_bundle_id INTEGER;
+BEGIN
+    -- Create bundle record
+    INSERT INTO pggit.bundles (repo_id, name, description, "references")
+    VALUES (p_repo_id, p_name, p_description, p_refs)
+    RETURNING id INTO v_bundle_id;
+
+    -- Collect all required objects
+    WITH RECURSIVE bundle_objects AS (
+        -- Start with referenced commits
+        SELECT hash, tree_hash, parent_hash
+        FROM commits c
+        WHERE hash = ANY(p_refs)
+        
+        UNION
+        
+        -- Include parent commits
+        SELECT c.hash, c.tree_hash, c.parent_hash
+        FROM commits c
+        JOIN bundle_objects b ON c.hash = b.parent_hash
+    ),
+    all_objects AS (
+        -- Include commit objects
+        SELECT hash::TEXT as hash, 'commit'::TEXT as type
+        FROM bundle_objects
+        
+        UNION ALL
+        
+        -- Include tree objects
+        SELECT hash, 'tree'
+        FROM trees
+        WHERE hash IN (SELECT tree_hash FROM bundle_objects)
+        
+        UNION ALL
+        
+        -- Include blob objects
+        SELECT hash, 'blob'
+        FROM blobs
+        WHERE hash IN (
+            SELECT e->>'hash'
+            FROM trees t,
+            jsonb_array_elements(t.entries) e
+            WHERE t.hash IN (SELECT tree_hash FROM bundle_objects)
+        )
+    )
+    SELECT encode(
+        string_agg(
+            CASE type
+                WHEN 'commit' THEN
+                    (SELECT encode(message::bytea, 'hex') FROM commits WHERE hash = o.hash)
+                WHEN 'tree' THEN
+                    (SELECT encode(entries::text::bytea, 'hex') FROM trees WHERE hash = o.hash)
+                WHEN 'blob' THEN
+                    (SELECT encode(content, 'hex') FROM blobs WHERE hash = o.hash)
+            END,
+            E'\n'
+        )::bytea,
+        'hex'
+    )::bytea INTO v_bundle_data
+    FROM all_objects o;
+
+    RETURN v_bundle_data;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.unbundle(
+    p_repo_id INTEGER,
+    p_bundle_data BYTEA
+) RETURNS TABLE (
+    type TEXT,
+    hash TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_line RECORD;
+BEGIN
+    FOR v_line IN
+        SELECT unnest(string_to_array(convert_from(p_bundle_data, 'UTF8'), E'\n')) as data
+    LOOP
+        -- Parse and store objects
+        IF substring(v_line.data, 1, 6) = 'commit' THEN
+            INSERT INTO commits (hash, message)
+            VALUES (
+                encode(sha256(decode(substring(v_line.data, 8), 'hex')), 'hex'),
+                convert_from(decode(substring(v_line.data, 8), 'hex'), 'UTF8')
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING 'commit', hash;
+        ELSIF substring(v_line.data, 1, 4) = 'tree' THEN
+            INSERT INTO trees (hash, entries)
+            VALUES (
+                encode(sha256(decode(substring(v_line.data, 6), 'hex')), 'hex'),
+                convert_from(decode(substring(v_line.data, 6), 'hex'), 'UTF8')::jsonb
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING 'tree', hash;
+        ELSIF substring(v_line.data, 1, 4) = 'blob' THEN
+            INSERT INTO blobs (hash, content)
+            VALUES (
+                encode(sha256(decode(substring(v_line.data, 6), 'hex')), 'hex'),
+                decode(substring(v_line.data, 6), 'hex')
+            )
+            ON CONFLICT DO NOTHING
+            RETURNING 'blob', hash;
+        END IF;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-diagnose.sql =====
+-- Path: /sql/functions/024-diagnose.sql
+-- Diagnostic information collection
+
+CREATE TABLE pggit.diagnostic_reports (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER REFERENCES repositories(id),
+    report_type TEXT NOT NULL,
+    report_data JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE OR REPLACE FUNCTION pggit.collect_diagnostics(
+    p_repo_id INTEGER
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_report_id INTEGER;
+    v_report_data JSONB;
+BEGIN
+    -- Collect repository info
+    WITH repo_info AS (
+        SELECT r.*,
+               (SELECT COUNT(*) FROM commits c) as commit_count,
+               (SELECT COUNT(*) FROM blobs b) as blob_count,
+               (SELECT COUNT(*) FROM trees t) as tree_count,
+               (SELECT COUNT(*) FROM refs rf) as ref_count
+        FROM repositories r
+        WHERE id = p_repo_id
+    ),
+    -- Collect size info
+    size_info AS (
+        SELECT 'blobs' as type, pg_size_pretty(sum(octet_length(content))) as total_size
+        FROM blobs
+        UNION ALL
+        SELECT 'trees', pg_size_pretty(sum(octet_length(entries::text)))
+        FROM trees
+    ),
+    -- Collect performance metrics
+    perf_metrics AS (
+        SELECT obj_description(oid) as last_gc_run
+        FROM pg_class
+        WHERE relname = 'blobs'
+    ),
+    -- Collect error info
+    error_info AS (
+        SELECT status, count(*) as count
+        FROM pggit.verify_integrity(p_repo_id)
+        GROUP BY status
+    )
+    SELECT jsonb_build_object(
+        'repository', row_to_json(repo_info),
+        'sizes', jsonb_agg(to_jsonb(size_info)),
+        'performance', to_jsonb(perf_metrics),
+        'errors', jsonb_agg(to_jsonb(error_info)),
+        'configs', (
+            SELECT jsonb_object_agg(key, value)
+            FROM pggit.config
+            WHERE repo_id = p_repo_id
+        )
+    )
+    INTO v_report_data
+    FROM repo_info, size_info, perf_metrics, error_info;
+
+    -- Store report
+    INSERT INTO pggit.diagnostic_reports (repo_id, report_type, report_data)
+    VALUES (p_repo_id, 'full', v_report_data)
+    RETURNING id INTO v_report_id;
+
+    RETURN v_report_id;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.get_diagnostic_report(
+    p_report_id INTEGER
+) RETURNS TABLE (
+    section TEXT,
+    content TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    WITH report AS (
+        SELECT report_data
+        FROM pggit.diagnostic_reports
+        WHERE id = p_report_id
+    )
+    SELECT 'Repository Info' as section,
+           jsonb_pretty(report_data->'repository') as content
+    FROM report
+    UNION ALL
+    SELECT 'Storage Usage',
+           jsonb_pretty(report_data->'sizes')
+    FROM report
+    UNION ALL
+    SELECT 'Performance Metrics',
+           jsonb_pretty(report_data->'performance')
+    FROM report
+    UNION ALL
+    SELECT 'Error Summary',
+           jsonb_pretty(report_data->'errors')
+    FROM report
+    UNION ALL
+    SELECT 'Configuration',
+           jsonb_pretty(report_data->'configs')
+    FROM report;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-extras.sql =====
+-- Path: /sql/functions/018-extras.sql
+-- Additional Git commands and utilities
+
+-- Cherry-pick implementation
+CREATE OR REPLACE FUNCTION pggit.cherry_pick(
+    p_repo_id INTEGER,
+    p_commit_hash TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_tree_hash TEXT;
+    v_new_commit TEXT;
+    v_message TEXT;
+    v_author TEXT;
+BEGIN
+    -- Get commit details
+    SELECT tree_hash, message, author 
+    INTO v_tree_hash, v_message, v_author
+    FROM commits WHERE hash = p_commit_hash;
+    
+    -- Create new commit with same tree
+    v_new_commit := pggit.create_commit(
+        p_repo_id,
+        v_tree_hash,
+        (SELECT commit_hash FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD'),
+        v_author,
+        v_message || ' (cherry-picked from ' || p_commit_hash || ')'
+    );
+    
+    -- Update HEAD
+    UPDATE refs
+    SET commit_hash = v_new_commit
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+    
+    RETURN v_new_commit;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Revert implementation
+CREATE OR REPLACE FUNCTION pggit.revert(
+    p_repo_id INTEGER,
+    p_commit_hash TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_parent_tree TEXT;
+    v_commit_tree TEXT;
+    v_new_tree TEXT;
+    v_new_commit TEXT;
+    v_message TEXT;
+BEGIN
+    -- Get trees and message
+    SELECT tree_hash, message,
+           (SELECT tree_hash FROM commits WHERE repo_id = p_repo_id AND hash = c.parent_hash)
+    INTO v_commit_tree, v_message, v_parent_tree
+    FROM commits c
+    WHERE c.repo_id = p_repo_id AND hash = p_commit_hash;
+    
+    -- Create inverse diff
+    v_new_tree := pggit.apply_inverse_diff(v_parent_tree, v_commit_tree);
+    
+    -- Create revert commit
+    v_new_commit := pggit.create_commit(
+        p_repo_id,
+        v_new_tree,
+        (SELECT commit_hash FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD'),
+        current_user,
+        'Revert "' || v_message || '"'
+    );
+    
+    -- Update HEAD
+    UPDATE refs
+    SET commit_hash = v_new_commit
+    WHERE repo_id = p_repo_id AND name = 'HEAD';
+    
+    RETURN v_new_commit;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Bisect implementation
+CREATE TABLE pggit.bisect_state (
+    repo_id INTEGER REFERENCES repositories(id),
+    start_commit TEXT NOT NULL,
+    good_commits TEXT[] DEFAULT ARRAY[]::TEXT[],
+    bad_commits TEXT[] DEFAULT ARRAY[]::TEXT[],
+    current_commit TEXT,
+    PRIMARY KEY (repo_id)
+);
+
+CREATE OR REPLACE FUNCTION pggit.bisect_start(
+    p_repo_id INTEGER,
+    p_bad_commit TEXT,
+    p_good_commit TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_mid_commit TEXT;
+BEGIN
+    -- Initialize bisect state
+    INSERT INTO pggit.bisect_state (repo_id, start_commit, good_commits, bad_commits)
+    VALUES (p_repo_id, p_bad_commit, ARRAY[p_good_commit], ARRAY[p_bad_commit])
+    ON CONFLICT (repo_id) DO UPDATE
+    SET start_commit = p_bad_commit,
+        good_commits = ARRAY[p_good_commit],
+        bad_commits = ARRAY[p_bad_commit];
+    
+    -- Find middle commit
+    SELECT hash INTO v_mid_commit
+    FROM (
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+               COUNT(*) OVER () as total
+        FROM pggit.rev_list(p_bad_commit, ARRAY[p_good_commit])
+    ) commits
+    WHERE rn = total/2;
+    
+    -- Update current commit
+    UPDATE pggit.bisect_state
+    SET current_commit = v_mid_commit
+    WHERE repo_id = p_repo_id;
+    
+    RETURN v_mid_commit;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.bisect_good(
+    p_repo_id INTEGER
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_current TEXT;
+    v_next TEXT;
+BEGIN
+    -- Get current state
+    SELECT current_commit INTO v_current
+    FROM pggit.bisect_state
+    WHERE repo_id = p_repo_id;
+    
+    -- Add to good commits
+    UPDATE pggit.bisect_state
+    SET good_commits = array_append(good_commits, v_current)
+    WHERE repo_id = p_repo_id;
+    
+    -- Find next commit to test
+    SELECT hash INTO v_next
+    FROM (
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+               COUNT(*) OVER () as total
+        FROM pggit.rev_list(
+            (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
+            (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
+        )
+    ) commits
+    WHERE rn = total/2;
+    
+    -- Update current commit
+    UPDATE pggit.bisect_state
+    SET current_commit = v_next
+    WHERE repo_id = p_repo_id;
+    
+    RETURN v_next;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.bisect_bad(
+    p_repo_id INTEGER
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_current TEXT;
+    v_next TEXT;
+BEGIN
+    -- Get current state
+    SELECT current_commit INTO v_current
+    FROM pggit.bisect_state
+    WHERE repo_id = p_repo_id;
+    
+    -- Add to bad commits
+    UPDATE pggit.bisect_state
+    SET bad_commits = array_append(bad_commits, v_current)
+    WHERE repo_id = p_repo_id;
+    
+    -- Find next commit to test
+    SELECT hash INTO v_next
+    FROM (
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+               COUNT(*) OVER () as total
+        FROM pggit.rev_list(
+            (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
+            (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
+        )
+    ) commits
+    WHERE rn = total/2;
+    
+    -- Update current commit
+    UPDATE pggit.bisect_state
+    SET current_commit = v_next
+    WHERE repo_id = p_repo_id;
+    
+    RETURN v_next;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.bisect_reset(
+    p_repo_id INTEGER
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    DELETE FROM pggit.bisect_state
+    WHERE repo_id = p_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Grep implementation
+CREATE OR REPLACE FUNCTION pggit.grep(
+    p_repo_id INTEGER,
+    p_pattern TEXT,
+    p_commit TEXT DEFAULT 'HEAD',
+    p_ignore_case BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (
+    file_path TEXT,
+    line_number INTEGER,
+    line_content TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_commit_hash TEXT;
+BEGIN
+    -- Resolve commit
+    IF p_commit = 'HEAD' THEN
+        SELECT commit_hash INTO v_commit_hash
+        FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD';
+    ELSE
+        v_commit_hash := p_commit;
+    END IF;
+    
+    RETURN QUERY
+    WITH files AS (
+        SELECT e->>'name' as path, b.content
+        FROM commits c
+        JOIN trees t ON c.repo_id = p_repo_id AND t.repo_id = p_repo_id AND c.tree_hash = t.hash,
+        jsonb_array_elements(t.entries) e
+        JOIN blobs b ON b.repo_id = p_repo_id AND e->>'hash' = b.hash
+        WHERE c.repo_id = p_repo_id AND c.hash = v_commit_hash
+    )
+    SELECT f.path,
+           s.line_number,
+           s.lines[s.line_number]
+    FROM files f,
+    LATERAL (
+        SELECT generate_subscripts(regexp_split_to_array(encode(f.content, 'escape'), E'\n'), 1) as line_number,
+               regexp_split_to_array(encode(f.content, 'escape'), E'\n') as lines
+    ) s
+    WHERE CASE 
+        WHEN p_ignore_case THEN 
+            s.lines[s.line_number] ~* p_pattern
+        ELSE 
+            s.lines[s.line_number] ~ p_pattern
+        END;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-instaweb.sql =====
+-- Path: /sql/functions/028-instaweb.sql
+-- Instaweb functionality for repository browsing
+
+CREATE TABLE pggit.instaweb_config (
+    repo_id INTEGER REFERENCES repositories(id),
+    port INTEGER NOT NULL DEFAULT 1234,
+    host TEXT NOT NULL DEFAULT 'localhost',
+    theme TEXT NOT NULL DEFAULT 'default',
+    auth_required BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id)
+);
+
+CREATE TABLE pggit.instaweb_users (
+    repo_id INTEGER REFERENCES repositories(id),
+    username TEXT NOT NULL,
+    password_hash TEXT NOT NULL,
+    is_admin BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, username)
+);
+
+CREATE TABLE pggit.instaweb_sessions (
+    repo_id INTEGER REFERENCES repositories(id),
+    session_id TEXT PRIMARY KEY,
+    username TEXT NOT NULL,
+    started_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    FOREIGN KEY (repo_id, username) REFERENCES pggit.instaweb_users(repo_id, username)
+);
+
+-- HTML Template for repository view
+CREATE OR REPLACE FUNCTION pggit.get_instaweb_template(
+    p_repo_id INTEGER
+) RETURNS TEXT SET search_path = pggit, public AS $$
+BEGIN
+    RETURN '
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{repo_name}} - pg_git web</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 20px; }
+        .header { background: #f0f0f0; padding: 10px; }
+        .commit-list { list-style: none; padding: 0; }
+        .commit { border-bottom: 1px solid #eee; padding: 10px 0; }
+        .file-tree { margin: 20px 0; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{repo_name}}</h1>
+        <div class="nav">
+            <a href="/tree">Files</a> |
+            <a href="/commits">History</a> |
+            <a href="/branches">Branches</a>
+        </div>
+    </div>
+    <div class="content">
+        {{content}}
+    </div>
+</body>
+</html>';
+END;
+$$ LANGUAGE plpgsql;
+
+-- Generate repository view
+CREATE OR REPLACE FUNCTION pggit.generate_repo_view(
+    p_repo_id INTEGER,
+    p_ref TEXT DEFAULT 'HEAD'
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_template TEXT;
+    v_content TEXT;
+    v_repo_name TEXT;
+BEGIN
+    SELECT name INTO v_repo_name
+    FROM repositories
+    WHERE id = p_repo_id;
+
+    -- Get history
+    WITH commit_list AS (
+        SELECT c.hash, 
+               c.message,
+               c.author,
+               c.timestamp
+        FROM pggit.get_log(p_repo_id, 10) c
+    )
+    SELECT string_agg(
+        format(
+            '<div class="commit">
+                <div class="commit-hash">%s</div>
+                <div class="commit-message">%s</div>
+                <div class="commit-author">%s</div>
+                <div class="commit-date">%s</div>
+            </div>',
+            substr(hash, 1, 8),
+            message,
+            author,
+            timestamp
+        ),
+        E'\n'
+    ) INTO v_content
+    FROM commit_list;
+
+    -- Get template and replace placeholders
+    v_template := pggit.get_instaweb_template(p_repo_id);
+    v_template := replace(v_template, '{{repo_name}}', v_repo_name);
+    v_template := replace(v_template, '{{content}}', v_content);
+
+    RETURN v_template;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Start instaweb server
+CREATE OR REPLACE FUNCTION pggit.start_instaweb(
+    p_repo_id INTEGER,
+    p_port INTEGER DEFAULT 1234,
+    p_host TEXT DEFAULT 'localhost',
+    p_auth_required BOOLEAN DEFAULT FALSE
+) RETURNS TEXT SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.instaweb_config (
+        repo_id, port, host, auth_required
+    ) VALUES (
+        p_repo_id, p_port, p_host, p_auth_required
+    )
+    ON CONFLICT (repo_id) DO UPDATE
+    SET port = p_port,
+        host = p_host,
+        auth_required = p_auth_required;
+
+    -- In a real implementation, this would start a web server
+    -- For now, just return the URL
+    RETURN format('http://%s:%s', p_host, p_port);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Stop instaweb server
+CREATE OR REPLACE FUNCTION pggit.stop_instaweb(
+    p_repo_id INTEGER
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    DELETE FROM pggit.instaweb_config
+    WHERE repo_id = p_repo_id;
+    
+    -- Clean up sessions
+    DELETE FROM pggit.instaweb_sessions
+    WHERE repo_id = p_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-merge-tree.sql =====
+-- Path: /sql/functions/022-merge-tree.sql
+-- Enhanced merge tree operations
+
+CREATE OR REPLACE FUNCTION pggit.merge_trees(
+    p_base_tree TEXT,
+    p_ours_tree TEXT,
+    p_theirs_tree TEXT
+) RETURNS TABLE (
+    path TEXT,
+    stage INTEGER,
+    mode TEXT,
+    hash TEXT,
+    status TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    -- Get all paths from all trees
+    RETURN QUERY
+    WITH all_paths AS (
+        SELECT e->>'name' as path,
+               e->>'mode' as mode,
+               e->>'hash' as hash,
+               'base' as source
+        FROM trees,
+        jsonb_array_elements(entries) e
+        WHERE hash = p_base_tree
+        
+        UNION ALL
+        
+        SELECT e->>'name' as path,
+               e->>'mode' as mode,
+               e->>'hash' as hash,
+               'ours' as source
+        FROM trees,
+        jsonb_array_elements(entries) e
+        WHERE hash = p_ours_tree
+        
+        UNION ALL
+        
+        SELECT e->>'name' as path,
+               e->>'mode' as mode,
+               e->>'hash' as hash,
+               'theirs' as source
+        FROM trees,
+        jsonb_array_elements(entries) e
+        WHERE hash = p_theirs_tree
+    ),
+    -- Analyze changes
+    analysis AS (
+        SELECT DISTINCT path,
+               bool_or(source = 'base') as in_base,
+               bool_or(source = 'ours') as in_ours,
+               bool_or(source = 'theirs') as in_theirs,
+               max(CASE WHEN source = 'base' THEN hash END) as base_hash,
+               max(CASE WHEN source = 'ours' THEN hash END) as ours_hash,
+               max(CASE WHEN source = 'theirs' THEN hash END) as theirs_hash,
+               max(CASE WHEN source = 'base' THEN mode END) as base_mode,
+               max(CASE WHEN source = 'ours' THEN mode END) as ours_mode,
+               max(CASE WHEN source = 'theirs' THEN mode END) as theirs_mode
+        FROM all_paths
+        GROUP BY path
+    )
+    SELECT path,
+           CASE 
+               WHEN NOT in_base AND in_ours AND in_theirs AND ours_hash != theirs_hash THEN 2  -- conflict
+               WHEN in_base AND in_ours AND in_theirs AND base_hash != ours_hash AND base_hash != theirs_hash THEN 2  -- conflict
+               ELSE 0  -- no conflict
+           END as stage,
+           COALESCE(ours_mode, theirs_mode, base_mode) as mode,
+           CASE 
+               WHEN ours_hash = theirs_hash THEN COALESCE(ours_hash, theirs_hash)
+               WHEN base_hash = ours_hash THEN theirs_hash
+               WHEN base_hash = theirs_hash THEN ours_hash
+               ELSE ours_hash
+           END as hash,
+           CASE 
+               WHEN NOT in_base AND in_ours AND in_theirs AND ours_hash != theirs_hash THEN 'both added'
+               WHEN in_base AND NOT in_ours AND NOT in_theirs THEN 'both deleted'
+               WHEN in_base AND in_ours AND in_theirs AND base_hash != ours_hash AND base_hash != theirs_hash THEN 'both modified'
+               WHEN in_base AND NOT in_ours AND in_theirs THEN 'deleted by us'
+               WHEN in_base AND in_ours AND NOT in_theirs THEN 'deleted by them'
+               WHEN NOT in_base AND in_ours AND NOT in_theirs THEN 'added by us'
+               WHEN NOT in_base AND NOT in_ours AND in_theirs THEN 'added by them'
+               WHEN in_base AND in_ours AND in_theirs AND base_hash = ours_hash AND base_hash != theirs_hash THEN 'modified by them'
+               WHEN in_base AND in_ours AND in_theirs AND base_hash != ours_hash AND base_hash = theirs_hash THEN 'modified by us'
+               ELSE 'clean'
+           END as status
+    FROM analysis
+    -- Only report paths that actually differ across base/ours/theirs.
+    WHERE NOT (ours_hash IS NOT DISTINCT FROM theirs_hash
+               AND ours_hash IS NOT DISTINCT FROM base_hash);
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-pack-refs.sql =====
+-- Path: /sql/functions/029-pack-refs.sql
+-- Pack refs for efficient repository access
+
+CREATE TABLE pggit.packed_refs (
+    repo_id INTEGER REFERENCES repositories(id),
+    ref_name TEXT NOT NULL,
+    commit_hash TEXT NOT NULL,
+    peeled_hash TEXT,
+    packed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, ref_name),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash),
+    FOREIGN KEY (repo_id, peeled_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.pack_refs(
+    p_repo_id INTEGER,
+    p_all BOOLEAN DEFAULT FALSE
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    -- Pack all refs or just frequently accessed ones
+    INSERT INTO pggit.packed_refs (repo_id, ref_name, commit_hash, peeled_hash)
+    SELECT r.repo_id, r.name, r.commit_hash,
+           CASE 
+               WHEN t.target_hash IS NOT NULL THEN t.target_hash
+               ELSE NULL
+           END
+    FROM refs r
+    LEFT JOIN pggit.tags t ON r.commit_hash = t.target_hash
+    WHERE r.repo_id = p_repo_id
+    AND r.name <> 'HEAD'
+    AND (p_all OR r.name IN (
+        SELECT name 
+        FROM refs 
+        WHERE repo_id = p_repo_id
+        ORDER BY name DESC 
+        LIMIT 100
+    ))
+    ON CONFLICT (repo_id, ref_name) DO UPDATE
+    SET commit_hash = EXCLUDED.commit_hash,
+        peeled_hash = EXCLUDED.peeled_hash,
+        packed_at = CURRENT_TIMESTAMP;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.unpack_refs(
+    p_repo_id INTEGER,
+    p_ref_pattern TEXT DEFAULT NULL
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM pggit.packed_refs
+    WHERE repo_id = p_repo_id
+    AND (p_ref_pattern IS NULL OR ref_name LIKE p_ref_pattern);
+    
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.verify_packed_refs(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    ref_name TEXT,
+    is_valid BOOLEAN,
+    error_message TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    SELECT pr.ref_name,
+           CASE 
+               WHEN r.commit_hash != pr.commit_hash THEN FALSE
+               WHEN pr.peeled_hash IS NOT NULL AND 
+                    NOT EXISTS (SELECT 1 FROM commits WHERE hash = pr.peeled_hash) THEN FALSE
+               ELSE TRUE
+           END as is_valid,
+           CASE 
+               WHEN r.commit_hash != pr.commit_hash THEN 'Commit hash mismatch'
+               WHEN pr.peeled_hash IS NOT NULL AND 
+                    NOT EXISTS (SELECT 1 FROM commits WHERE hash = pr.peeled_hash) THEN 'Invalid peeled hash'
+               ELSE 'Valid'
+           END as error_message
+    FROM pggit.packed_refs pr
+    JOIN refs r ON r.name = pr.ref_name
+    WHERE pr.repo_id = p_repo_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-plumbing.sql =====
+-- Path: /sql/functions/017-plumbing.sql
+-- Git plumbing commands implementation
+
+CREATE OR REPLACE FUNCTION pggit.cat_file(
+    p_repo_id INTEGER,
+    p_hash TEXT,
+    p_type TEXT DEFAULT NULL
+) RETURNS TABLE (
+    object_type TEXT,
+    size BIGINT,
+    content TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    -- Try blobs
+    RETURN QUERY
+    SELECT 'blob'::TEXT,
+           octet_length(content)::BIGINT,
+           encode(content, 'escape')
+    FROM blobs WHERE repo_id = p_repo_id AND hash = p_hash
+    AND (p_type IS NULL OR p_type = 'blob');
+    
+    IF FOUND THEN RETURN; END IF;
+    
+    -- Try trees
+    RETURN QUERY
+    SELECT 'tree'::TEXT,
+           octet_length(entries::TEXT)::BIGINT,
+           entries::TEXT
+    FROM trees WHERE repo_id = p_repo_id AND hash = p_hash
+    AND (p_type IS NULL OR p_type = 'tree');
+    
+    IF FOUND THEN RETURN; END IF;
+    
+    -- Try commits
+    RETURN QUERY
+    SELECT 'commit'::TEXT,
+           octet_length(message)::BIGINT,
+           message
+    FROM commits WHERE repo_id = p_repo_id AND hash = p_hash
+    AND (p_type IS NULL OR p_type = 'commit');
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.hash_object(
+    p_repo_id INTEGER,
+    p_content BYTEA,
+    p_type TEXT DEFAULT 'blob'
+) RETURNS TEXT SET search_path = pggit, public AS $$
+BEGIN
+    CASE p_type
+        WHEN 'blob' THEN
+            RETURN pggit.create_blob(p_repo_id, p_content);
+        WHEN 'tree' THEN
+            RETURN pggit.create_tree(p_repo_id, p_content::TEXT::jsonb);
+        ELSE
+            RAISE EXCEPTION 'Unsupported object type: %', p_type;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.ls_tree(
+    p_repo_id INTEGER,
+    p_tree_hash TEXT,
+    p_recursive BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (
+    mode TEXT,
+    type TEXT,
+    hash TEXT,
+    path TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    IF NOT p_recursive THEN
+        RETURN QUERY
+        SELECT (e->>'mode')::TEXT,
+               (e->>'type')::TEXT,
+               (e->>'hash')::TEXT,
+               (e->>'name')::TEXT
+        FROM trees t,
+             jsonb_array_elements(t.entries) e
+        WHERE t.repo_id = p_repo_id AND t.hash = p_tree_hash;
+    ELSE
+        RETURN QUERY
+        WITH RECURSIVE tree_entries AS (
+            -- Base case: direct entries
+            SELECT (e->>'mode')::TEXT as mode,
+                   (e->>'type')::TEXT as type,
+                   (e->>'hash')::TEXT as hash,
+                   (e->>'name')::TEXT as path,
+                   1 as level
+            FROM trees t,
+                 jsonb_array_elements(t.entries) e
+            WHERE t.repo_id = p_repo_id AND t.hash = p_tree_hash
+            
+            
+            UNION ALL
+            
+            -- Recursive case: subtrees
+            SELECT (se->>'mode')::TEXT,
+                   (se->>'type')::TEXT,
+                   (se->>'hash')::TEXT,
+                   te.path || '/' || (se->>'name')::TEXT,
+                   te.level + 1
+            FROM tree_entries te
+            JOIN trees t ON t.repo_id = p_repo_id AND te.hash = t.hash,
+            jsonb_array_elements(t.entries) se
+            WHERE te.type = 'tree'
+        )
+        SELECT mode, type, hash, path
+        FROM tree_entries
+        ORDER BY path;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.merge_base(
+    p_repo_id INTEGER,
+    p_commit1 TEXT,
+    p_commit2 TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+    -- Reuse existing merge base finding function
+    SELECT pggit.find_merge_base(p_repo_id, p_commit1, p_commit2);
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.rev_list(
+    p_repo_id INTEGER,
+    p_start_commit TEXT,
+    p_exclude_commits TEXT[] DEFAULT ARRAY[]::TEXT[]
+) RETURNS TABLE (
+    hash TEXT,
+    commit_data JSONB
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE commit_list AS (
+        -- Start commit
+        SELECT hash,
+               jsonb_build_object(
+                   'tree', tree_hash,
+                   'parent', parent_hash,
+                   'author', author,
+                   'message', message,
+                   'timestamp', timestamp
+               ) as commit_data
+        FROM commits
+        WHERE repo_id = p_repo_id AND hash = p_start_commit
+        
+        UNION
+        
+        -- Parent commits
+        SELECT c.hash,
+               jsonb_build_object(
+                   'tree', c.tree_hash,
+                   'parent', c.parent_hash,
+                   'author', c.author,
+                   'message', c.message,
+                   'timestamp', c.timestamp
+               ) as commit_data
+        FROM commit_list cl
+        JOIN commits c ON c.repo_id = p_repo_id AND cl.commit_data->>'parent' = c.hash
+        WHERE c.hash <> ALL(p_exclude_commits)
+    )
+    SELECT * FROM commit_list;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-repack.sql =====
+-- Path: /sql/functions/030-repack.sql
+-- Repack objects for efficient storage
+
+CREATE TABLE pggit.pack_files (
+    id SERIAL PRIMARY KEY,
+    repo_id INTEGER REFERENCES repositories(id),
+    pack_hash TEXT NOT NULL,
+    object_count INTEGER NOT NULL,
+    size_bytes BIGINT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pggit.packed_objects (
+    pack_id INTEGER REFERENCES pggit.pack_files(id),
+    object_hash TEXT NOT NULL,
+    "offset" INTEGER NOT NULL,
+    size INTEGER NOT NULL,
+    type TEXT NOT NULL,
+    delta_base TEXT,
+    PRIMARY KEY (pack_id, object_hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.repack(
+    p_repo_id INTEGER,
+    p_aggressive BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (
+    objects_packed INTEGER,
+    space_saved BIGINT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_pack_id INTEGER;
+    v_old_size BIGINT;
+    v_new_size BIGINT;
+    v_pack_hash TEXT;
+    v_object_count INTEGER;
+BEGIN
+    -- Calculate current storage size
+    SELECT COALESCE(SUM(octet_length(content)), 0) +
+           COALESCE(SUM(octet_length(entries::text)), 0)
+    INTO v_old_size
+    FROM (
+        SELECT content, NULL::jsonb as entries FROM blobs
+        UNION ALL
+        SELECT NULL::bytea, entries FROM trees
+    ) objects;
+
+    -- Create new pack
+    INSERT INTO pggit.pack_files (repo_id, pack_hash, object_count, size_bytes)
+    SELECT p_repo_id,
+           encode(sha256(convert_to(string_agg(hash, ''), 'UTF8')), 'hex'),
+           count(*),
+           sum(
+               CASE 
+                   WHEN content IS NOT NULL THEN octet_length(content)
+                   ELSE octet_length(entries::text)
+               END
+           )
+    FROM (
+        SELECT hash, content, NULL::jsonb as entries 
+        FROM blobs
+        UNION ALL
+        SELECT hash, NULL::bytea, entries 
+        FROM trees
+    ) objects
+    RETURNING id, size_bytes, object_count 
+    INTO v_pack_id, v_new_size, v_object_count;
+
+    -- Pack objects with delta compression if aggressive
+    IF p_aggressive THEN
+        INSERT INTO pggit.packed_objects (
+            pack_id, object_hash, "offset", size, type, delta_base
+        )
+        WITH object_analysis AS (
+            SELECT hash,
+                   CASE 
+                       WHEN content IS NOT NULL THEN 'blob'
+                       ELSE 'tree'
+                   END as type,
+                   CASE 
+                       WHEN content IS NOT NULL THEN content
+                       ELSE entries::text::bytea
+                   END as data,
+                   row_number() OVER (ORDER BY hash) as "offset"
+            FROM (
+                SELECT hash, content, NULL::jsonb as entries 
+                FROM blobs
+                UNION ALL
+                SELECT hash, NULL::bytea, entries 
+                FROM trees
+            ) objects
+        ),
+        delta_candidates AS (
+            SELECT a1.hash as obj_hash,
+                   a1.type,
+                   a1."offset",
+                   octet_length(a1.data) as size,
+                   a2.hash as base_hash
+            FROM object_analysis a1
+            LEFT JOIN object_analysis a2 ON a1.type = a2.type
+            AND similarity(a1.data, a2.data) > 0.5
+            AND a1.hash != a2.hash
+            ORDER BY similarity(a1.data, a2.data) DESC
+        )
+        SELECT v_pack_id,
+               obj_hash,
+               "offset",
+               size,
+               type,
+               base_hash
+        FROM delta_candidates;
+    ELSE
+        INSERT INTO pggit.packed_objects (
+            pack_id, object_hash, "offset", size, type
+        )
+        SELECT v_pack_id,
+               hash,
+               row_number() OVER (ORDER BY hash),
+               CASE 
+                   WHEN content IS NOT NULL THEN octet_length(content)
+                   ELSE octet_length(entries::text)
+               END,
+               CASE 
+                   WHEN content IS NOT NULL THEN 'blob'
+                   ELSE 'tree'
+               END
+        FROM (
+            SELECT hash, content, NULL::jsonb as entries 
+            FROM blobs
+            UNION ALL
+            SELECT hash, NULL::bytea, entries 
+            FROM trees
+        ) objects;
+    END IF;
+
+    RETURN QUERY
+    SELECT v_object_count as objects_packed,
+           (v_old_size - v_new_size) as space_saved;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.unpack(
+    p_repo_id INTEGER,
+    p_pack_id INTEGER DEFAULT NULL
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+DECLARE
+    v_count INTEGER;
+BEGIN
+    DELETE FROM pggit.packed_objects po
+    USING pggit.pack_files pf
+    WHERE po.pack_id = pf.id
+    AND pf.repo_id = p_repo_id
+    AND (p_pack_id IS NULL OR pf.id = p_pack_id);
+    
+    DELETE FROM pggit.pack_files
+    WHERE repo_id = p_repo_id
+    AND (p_pack_id IS NULL OR id = p_pack_id);
+    
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-replace.sql =====
+-- Path: /sql/functions/031-replace.sql
+-- Replace object references
+
+CREATE TABLE pggit.replacements (
+    repo_id INTEGER REFERENCES repositories(id),
+    original_hash TEXT NOT NULL,
+    replacement_hash TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('commit', 'tree', 'blob')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, original_hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.replace(
+    p_repo_id INTEGER,
+    p_original TEXT,
+    p_replacement TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_type TEXT;
+BEGIN
+    -- Determine object type
+    IF EXISTS (SELECT 1 FROM commits WHERE repo_id = p_repo_id AND hash = p_original) THEN
+        v_type := 'commit';
+    ELSIF EXISTS (SELECT 1 FROM trees WHERE repo_id = p_repo_id AND hash = p_original) THEN
+        v_type := 'tree';
+    ELSIF EXISTS (SELECT 1 FROM blobs WHERE repo_id = p_repo_id AND hash = p_original) THEN
+        v_type := 'blob';
+    ELSE
+        RAISE EXCEPTION 'Original object not found';
+    END IF;
+
+    -- Verify replacement exists and is the same object type
+    IF NOT EXISTS (
+        SELECT 1 FROM commits WHERE v_type = 'commit' AND repo_id = p_repo_id AND hash = p_replacement
+        UNION ALL
+        SELECT 1 FROM trees   WHERE v_type = 'tree'   AND repo_id = p_repo_id AND hash = p_replacement
+        UNION ALL
+        SELECT 1 FROM blobs   WHERE v_type = 'blob'   AND repo_id = p_repo_id AND hash = p_replacement
+    ) THEN
+        RAISE EXCEPTION 'Replacement object not found or wrong type';
+    END IF;
+
+    INSERT INTO pggit.replacements (repo_id, original_hash, replacement_hash, type)
+    VALUES (p_repo_id, p_original, p_replacement, v_type)
+    ON CONFLICT (repo_id, original_hash) 
+    DO UPDATE SET replacement_hash = p_replacement;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.get_replaced_hash(
+    p_repo_id INTEGER,
+    p_hash TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+    SELECT COALESCE(replacement_hash, p_hash)
+    FROM pggit.replacements
+    WHERE repo_id = p_repo_id
+    AND original_hash = p_hash;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.remove_replace(
+    p_repo_id INTEGER,
+    p_original TEXT
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
+    WITH deleted AS (
+        DELETE FROM pggit.replacements
+        WHERE repo_id = p_repo_id
+        AND original_hash = p_original
+        RETURNING 1
+    )
+    SELECT EXISTS (SELECT 1 FROM deleted);
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.list_replace(
+    p_repo_id INTEGER
+) RETURNS TABLE (
+    original_hash TEXT,
+    replacement_hash TEXT,
+    type TEXT,
+    created_at TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
+    SELECT original_hash, replacement_hash, type, created_at
+    FROM pggit.replacements
+    WHERE repo_id = p_repo_id
+    ORDER BY created_at DESC;
+$$ LANGUAGE sql;
+
+-- ===== sql/pgit-rerere.sql =====
+-- Path: /sql/functions/023-rerere.sql
+-- Reuse recorded resolution
+
+CREATE TABLE pggit.rerere_cache (
+    repo_id INTEGER REFERENCES repositories(id),
+    conflict_hash TEXT NOT NULL,
+    path TEXT NOT NULL,
+    resolution_blob_hash TEXT,
+    recorded_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    used_count INTEGER DEFAULT 0,
+    last_used TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (repo_id, conflict_hash, path),
+    FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.hash_conflict(
+    p_our_blob TEXT,
+    p_their_blob TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+    SELECT encode(sha256(
+        COALESCE(o.content, ''::BYTEA) || 
+        COALESCE(t.content, ''::BYTEA)
+    ), 'hex')
+    FROM blobs o
+    FULL OUTER JOIN blobs t ON TRUE
+    WHERE o.hash = p_our_blob
+    AND t.hash = p_their_blob;
+$$ LANGUAGE sql;
+
+CREATE OR REPLACE FUNCTION pggit.record_resolution(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_our_blob TEXT,
+    p_their_blob TEXT,
+    p_resolution_blob TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_conflict_hash TEXT;
+BEGIN
+    v_conflict_hash := pggit.hash_conflict(p_our_blob, p_their_blob);
+    
+    INSERT INTO pggit.rerere_cache (
+        repo_id, conflict_hash, path, resolution_blob_hash
+    ) VALUES (
+        p_repo_id, v_conflict_hash, p_path, p_resolution_blob
+    )
+    ON CONFLICT (repo_id, conflict_hash, path) 
+    DO UPDATE SET 
+        resolution_blob_hash = p_resolution_blob,
+        recorded_at = CURRENT_TIMESTAMP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.find_resolution(
+    p_repo_id INTEGER,
+    p_path TEXT,
+    p_our_blob TEXT,
+    p_their_blob TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_conflict_hash TEXT;
+    v_resolution_hash TEXT;
+BEGIN
+    v_conflict_hash := pggit.hash_conflict(p_our_blob, p_their_blob);
+    
+    UPDATE pggit.rerere_cache
+    SET used_count = used_count + 1,
+        last_used = CURRENT_TIMESTAMP
+    WHERE repo_id = p_repo_id
+    AND conflict_hash = v_conflict_hash
+    AND path = p_path
+    RETURNING resolution_blob_hash INTO v_resolution_hash;
+    
+    RETURN v_resolution_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.clear_rerere_cache(
+    p_repo_id INTEGER,
+    p_older_than INTERVAL DEFAULT NULL
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+    DELETE FROM pggit.rerere_cache
+    WHERE repo_id = p_repo_id
+    AND (
+        p_older_than IS NULL OR
+        recorded_at < (CURRENT_TIMESTAMP - p_older_than)
+    )
+    RETURNING 1;
+$$ LANGUAGE sql;
+
+-- ===== sql/pgit-sparse.sql =====
+-- Path: /sql/functions/021-sparse-checkout.sql
+-- Sparse checkout functionality
+
+CREATE TABLE pggit.sparse_patterns (
+    repo_id INTEGER REFERENCES repositories(id),
+    pattern TEXT NOT NULL,
+    is_negative BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, pattern)
+);
+
+CREATE OR REPLACE FUNCTION pggit.sparse_checkout_set(
+    p_repo_id INTEGER,
+    p_patterns TEXT[]
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    -- Clear existing patterns
+    DELETE FROM pggit.sparse_patterns
+    WHERE repo_id = p_repo_id;
+    
+    -- Add new patterns
+    INSERT INTO pggit.sparse_patterns (repo_id, pattern, is_negative)
+    SELECT p_repo_id,
+           pattern,
+           pattern LIKE '!%'
+    FROM unnest(p_patterns) pattern;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.sparse_checkout_add(
+    p_repo_id INTEGER,
+    p_patterns TEXT[]
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.sparse_patterns (repo_id, pattern, is_negative)
+    SELECT p_repo_id,
+           pattern,
+           pattern LIKE '!%'
+    FROM unnest(p_patterns) pattern
+    ON CONFLICT (repo_id, pattern) DO NOTHING;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.is_path_in_sparse_checkout(
+    p_repo_id INTEGER,
+    p_path TEXT
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
+DECLARE
+    v_result BOOLEAN;
+BEGIN
+    WITH matched_patterns AS (
+        SELECT pattern, is_negative,
+               p_path LIKE replace(
+                   replace(pattern, '!', ''),
+                   '*', '%'
+               ) as matches
+        FROM pggit.sparse_patterns
+        WHERE repo_id = p_repo_id
+        ORDER BY is_negative, length(pattern) DESC
+    )
+    SELECT COALESCE(
+        bool_or(
+            CASE 
+                WHEN is_negative THEN NOT matches
+                ELSE matches
+            END
+        ),
+        TRUE  -- If no patterns, include everything
+    )
+    INTO v_result
+    FROM matched_patterns
+    WHERE matches;
+    
+    RETURN v_result;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Override tree functions to respect sparse checkout
+CREATE OR REPLACE FUNCTION pggit.get_tree_files(
+    p_repo_id INTEGER,
+    p_tree_hash TEXT
+) RETURNS TABLE (
+    path TEXT,
+    blob_hash TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    WITH RECURSIVE tree_files AS (
+        SELECT e->>'name' as path,
+               e->>'hash' as hash,
+               e->>'type' as type
+        FROM trees,
+        jsonb_array_elements(entries) e
+        WHERE hash = p_tree_hash
+        
+        UNION ALL
+        
+        SELECT tf.path || '/' || e->>'name',
+               e->>'hash',
+               e->>'type'
+        FROM tree_files tf
+        JOIN trees t ON tf.hash = t.hash,
+        jsonb_array_elements(t.entries) e
+        WHERE tf.type = 'tree'
+    )
+    SELECT tf.path, tf.hash
+    FROM tree_files tf
+    WHERE tf.type = 'blob'
+    AND pggit.is_path_in_sparse_checkout(p_repo_id, tf.path);
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-submodule.sql =====
+-- Path: /sql/functions/020-submodule.sql
+-- Submodule support
+
+CREATE TABLE pggit.submodules (
+    repo_id INTEGER REFERENCES repositories(id),
+    name TEXT NOT NULL,
+    path TEXT NOT NULL,
+    url TEXT NOT NULL,
+    branch TEXT DEFAULT 'main',
+    commit_hash TEXT,
+    PRIMARY KEY (repo_id, path)
+);
+
+CREATE OR REPLACE FUNCTION pggit.submodule_add(
+    p_repo_id INTEGER,
+    p_repository_url TEXT,
+    p_path TEXT,
+    p_name TEXT DEFAULT NULL
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_name TEXT;
+    v_commit_hash TEXT;
+BEGIN
+    -- Generate name if not provided
+    v_name := COALESCE(p_name, regexp_replace(p_path, '.*/', ''));
+    
+    -- Clone submodule
+    v_commit_hash := pggit.clone(p_repository_url, v_name, p_path);
+    
+    -- Register submodule
+    INSERT INTO pggit.submodules (repo_id, name, path, url, commit_hash)
+    VALUES (p_repo_id, v_name, p_path, p_repository_url, v_commit_hash);
+    
+    RETURN v_commit_hash;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.submodule_update(
+    p_repo_id INTEGER,
+    p_path TEXT DEFAULT NULL,
+    p_recursive BOOLEAN DEFAULT FALSE
+) RETURNS TABLE (
+    submodule_path TEXT,
+    old_commit TEXT,
+    new_commit TEXT
+) SET search_path = pggit, public AS $$
+BEGIN
+    RETURN QUERY
+    WITH updated AS (
+        SELECT s.path,
+               s.commit_hash as old_commit,
+               pggit.pull(s.repo_id, 'origin', s.branch) as new_commit
+        FROM pggit.submodules s
+        WHERE s.repo_id = p_repo_id
+        AND (p_path IS NULL OR s.path = p_path)
+    )
+    UPDATE pggit.submodules s
+    SET commit_hash = u.new_commit
+    FROM updated u
+    WHERE s.repo_id = p_repo_id AND s.path = u.path
+    RETURNING s.path, u.old_commit, u.new_commit;
+    
+    -- Handle recursive update
+    IF p_recursive THEN
+        RETURN QUERY
+        SELECT * FROM pggit.submodule_update_recursive(p_repo_id, p_path);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.submodule_update_recursive(
+    p_repo_id INTEGER,
+    p_path TEXT DEFAULT NULL
+) RETURNS TABLE (
+    submodule_path TEXT,
+    old_commit TEXT,
+    new_commit TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_submodule RECORD;
+BEGIN
+    FOR v_submodule IN
+        SELECT s.* 
+        FROM pggit.submodules s
+        WHERE s.repo_id = p_repo_id
+        AND (p_path IS NULL OR s.path = p_path)
+    LOOP
+        RETURN QUERY
+        SELECT * FROM pggit.submodule_update(v_submodule.repo_id, NULL, TRUE);
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-verify-commit.sql =====
+-- Path: /sql/functions/025-verify-commit.sql
+-- Commit verification with GPG
+
+CREATE TABLE pggit.gpg_keys (
+    repo_id INTEGER REFERENCES repositories(id),
+    key_id TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    trust_level TEXT CHECK (trust_level IN ('unknown', 'never', 'marginal', 'full', 'ultimate')),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, key_id)
+);
+
+CREATE TABLE pggit.commit_signatures (
+    repo_id INTEGER REFERENCES repositories(id),
+    commit_hash TEXT NOT NULL,
+    key_id TEXT NOT NULL,
+    signature TEXT NOT NULL,
+    signed_data TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, commit_hash),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
+);
+
+CREATE OR REPLACE FUNCTION pggit.add_gpg_key(
+    p_repo_id INTEGER,
+    p_key_id TEXT,
+    p_public_key TEXT,
+    p_user_id TEXT,
+    p_trust_level TEXT DEFAULT 'unknown'
+) RETURNS VOID SET search_path = pggit, public AS $$
+BEGIN
+    INSERT INTO pggit.gpg_keys (repo_id, key_id, public_key, user_id, trust_level)
+    VALUES (p_repo_id, p_key_id, p_public_key, p_user_id, p_trust_level)
+    ON CONFLICT (repo_id, key_id) DO UPDATE 
+    SET public_key = p_public_key,
+        user_id = p_user_id,
+        trust_level = p_trust_level;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.verify_commit(
+    p_repo_id INTEGER,
+    p_commit_hash TEXT,
+    p_require_trust_level TEXT DEFAULT NULL
+) RETURNS TABLE (
+    is_valid BOOLEAN,
+    key_id TEXT,
+    user_id TEXT,
+    trust_level TEXT,
+    verification_message TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_signature RECORD;
+    v_key RECORD;
+BEGIN
+    -- Get signature info
+    SELECT * INTO v_signature
+    FROM pggit.commit_signatures
+    WHERE repo_id = p_repo_id
+    AND commit_hash = p_commit_hash;
+
+    IF NOT FOUND THEN
+        RETURN QUERY
+        SELECT FALSE, NULL::TEXT, NULL::TEXT, NULL::TEXT, 'No signature found'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Get key info
+    SELECT * INTO v_key
+    FROM pggit.gpg_keys
+    WHERE repo_id = p_repo_id
+    AND key_id = v_signature.key_id;
+
+    IF NOT FOUND THEN
+        RETURN QUERY
+        SELECT FALSE, v_signature.key_id, NULL::TEXT, NULL::TEXT, 'Unknown key'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Check trust level if required
+    IF p_require_trust_level IS NOT NULL AND 
+       v_key.trust_level NOT IN ('full', 'ultimate') THEN
+        RETURN QUERY
+        SELECT FALSE, v_key.key_id, v_key.user_id, v_key.trust_level,
+               'Insufficient trust level'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Here you would implement actual GPG verification
+    -- For now, we'll assume any stored signature is valid
+    RETURN QUERY
+    SELECT TRUE, v_key.key_id, v_key.user_id, v_key.trust_level,
+           'Valid signature'::TEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.sign_commit(
+    p_repo_id INTEGER,
+    p_commit_hash TEXT,
+    p_key_id TEXT,
+    p_signature TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_signed_data TEXT;
+BEGIN
+    -- Construct signed data from commit
+    SELECT tree_hash || parent_hash || author || message INTO v_signed_data
+    FROM commits
+    WHERE hash = p_commit_hash;
+
+    INSERT INTO pggit.commit_signatures (
+        repo_id, commit_hash, key_id, signature, signed_data
+    ) VALUES (
+        p_repo_id, p_commit_hash, p_key_id, p_signature, v_signed_data
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- ===== sql/pgit-verify-tag.sql =====
+-- Path: /sql/functions/026-verify-tag.sql
+-- Tag verification with GPG
+
+CREATE TABLE pggit.tag_signatures (
+    repo_id INTEGER REFERENCES repositories(id),
+    tag_name TEXT NOT NULL,
+    key_id TEXT NOT NULL,
+    signature TEXT NOT NULL,
+    signed_data TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repo_id, tag_name),
+    FOREIGN KEY (repo_id, key_id) REFERENCES pggit.gpg_keys(repo_id, key_id)
+);
+
+CREATE OR REPLACE FUNCTION pggit.sign_tag(
+    p_repo_id INTEGER,
+    p_tag_name TEXT,
+    p_key_id TEXT,
+    p_signature TEXT
+) RETURNS VOID SET search_path = pggit, public AS $$
+DECLARE
+    v_signed_data TEXT;
+BEGIN
+    -- Construct signed data from tag
+    SELECT target_hash || tagger || message INTO v_signed_data
+    FROM pggit.tags
+    WHERE repo_id = p_repo_id AND name = p_tag_name;
+
+    INSERT INTO pggit.tag_signatures (
+        repo_id, tag_name, key_id, signature, signed_data
+    ) VALUES (
+        p_repo_id, p_tag_name, p_key_id, p_signature, v_signed_data
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.verify_tag(
+    p_repo_id INTEGER,
+    p_tag_name TEXT,
+    p_require_trust_level TEXT DEFAULT NULL
+) RETURNS TABLE (
+    is_valid BOOLEAN,
+    key_id TEXT,
+    user_id TEXT,
+    trust_level TEXT,
+    verification_message TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_signature RECORD;
+    v_key RECORD;
+BEGIN
+    -- Get signature info
+    SELECT * INTO v_signature
+    FROM pggit.tag_signatures
+    WHERE repo_id = p_repo_id
+    AND tag_name = p_tag_name;
+
+    IF NOT FOUND THEN
+        RETURN QUERY
+        SELECT FALSE, NULL::TEXT, NULL::TEXT, NULL::TEXT, 'No signature found'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Get key info
+    SELECT * INTO v_key
+    FROM pggit.gpg_keys
+    WHERE repo_id = p_repo_id
+    AND key_id = v_signature.key_id;
+
+    -- Check trust level
+    IF p_require_trust_level IS NOT NULL AND 
+       v_key.trust_level NOT IN ('full', 'ultimate') THEN
+        RETURN QUERY
+        SELECT FALSE, v_key.key_id, v_key.user_id, v_key.trust_level,
+               'Insufficient trust level'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Here you would implement actual GPG verification
+    -- For now, we assume stored signatures are valid
+    RETURN QUERY
+    SELECT TRUE, v_key.key_id, v_key.user_id, v_key.trust_level,
+           'Valid signature'::TEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION pggit.verify_all_tags(
+    p_repo_id INTEGER,
+    p_require_trust_level TEXT DEFAULT NULL
+) RETURNS TABLE (
+    tag_name TEXT,
+    is_valid BOOLEAN,
+    verification_message TEXT
+) SET search_path = pggit, public AS $$
+    SELECT t.name,
+           v.is_valid,
+           v.verification_message
+    FROM pggit.tags t
+    LEFT JOIN LATERAL pggit.verify_tag(p_repo_id, t.name, p_require_trust_level) v ON TRUE
+    WHERE t.repo_id = p_repo_id
+    ORDER BY t.name;
+$$ LANGUAGE sql;
+
+-- ===== sql/pgit-whatchanged.sql =====
+-- Path: /sql/functions/027-whatchanged.sql
+-- Whatchanged command implementation
+
+CREATE OR REPLACE FUNCTION pggit.whatchanged(
+    p_repo_id INTEGER,
+    p_since TEXT DEFAULT NULL,
+    p_until TEXT DEFAULT 'HEAD',
+    p_paths TEXT[] DEFAULT NULL
+) RETURNS TABLE (
+    commit_hash TEXT,
+    author TEXT,
+    "timestamp" TIMESTAMP WITH TIME ZONE,
+    message TEXT,
+    path TEXT,
+    change_type TEXT,
+    old_mode TEXT,
+    new_mode TEXT,
+    old_hash TEXT,
+    new_hash TEXT
+) SET search_path = pggit, public AS $$
+DECLARE
+    v_since_hash TEXT;
+    v_until_hash TEXT;
+BEGIN
+    -- Resolve commit references
+    IF p_until = 'HEAD' THEN
+        SELECT commit_hash INTO v_until_hash
+        FROM refs WHERE name = 'HEAD';
+    ELSE
+        v_until_hash := p_until;
+    END IF;
+
+    -- Get commit history with changes
+    RETURN QUERY
+    WITH RECURSIVE commit_history AS (
+        -- Start from until commit
+        SELECT repo_id, hash, parent_hash, author, timestamp, message, tree_hash
+        FROM commits
+        WHERE repo_id = p_repo_id
+          AND hash = v_until_hash
+
+        UNION ALL
+
+        -- Walk back through parents
+        SELECT c.repo_id, c.hash, c.parent_hash, c.author, c.timestamp, c.message, c.tree_hash
+        FROM commits c
+        JOIN commit_history ch ON c.hash = ch.parent_hash
+        WHERE c.repo_id = p_repo_id
+          AND (p_since IS NULL OR c.hash != p_since)
+    ),
+    file_changes AS (
+        SELECT
+            ch.hash as commit_hash,
+            ch.author,
+            ch.timestamp,
+            ch.message,
+            dt.path,
+            dt.change_type,
+            dt.old_mode,
+            dt.new_mode,
+            dt.old_hash,
+            dt.new_hash
+        FROM commit_history ch
+        LEFT JOIN LATERAL (
+            SELECT repo_id, tree_hash
+            FROM commits
+            WHERE hash = ch.parent_hash
+              AND repo_id = ch.repo_id
+        ) parent ON TRUE
+        CROSS JOIN LATERAL (
+            SELECT d.path,
+                   CASE
+                       WHEN d.old_hash IS NULL THEN 'A'  -- Added
+                       WHEN d.new_hash IS NULL THEN 'D'  -- Deleted
+                       ELSE 'M'                          -- Modified
+                   END as change_type,
+                   t1.mode as old_mode,
+                   t2.mode as new_mode,
+                   d.old_hash,
+                   d.new_hash
+            FROM pggit.diff_trees(
+                COALESCE(parent.repo_id, ch.repo_id),
+                parent.tree_hash,
+                ch.tree_hash
+            ) d
+            LEFT JOIN pggit.get_tree_entry(parent.tree_hash, d.path) t1 ON TRUE
+            LEFT JOIN pggit.get_tree_entry(ch.tree_hash, d.path) t2 ON TRUE
+            WHERE p_paths IS NULL OR d.path = ANY(p_paths)
+        ) dt
+    )
+    SELECT *
+    FROM file_changes
+    ORDER BY timestamp DESC, commit_hash, path;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Helper function to get a single tree entry
+CREATE OR REPLACE FUNCTION pggit.get_tree_entry(
+    p_tree_hash TEXT,
+    p_path TEXT
+) RETURNS TABLE (
+    mode TEXT,
+    type TEXT,
+    hash TEXT
+) SET search_path = pggit, public AS $$
+    SELECT (e->>'mode')::TEXT,
+           (e->>'type')::TEXT,
+           (e->>'hash')::TEXT
+    FROM trees,
+    jsonb_array_elements(entries) e
+    WHERE hash = p_tree_hash
+    AND e->>'name' = p_path;
+$$ LANGUAGE sql;

--- a/sql/pgit-advanced-commands.sql
+++ b/sql/pgit-advanced-commands.sql
@@ -2,7 +2,7 @@
 -- Additional Git commands implementation
 
 -- Notes support
-CREATE TABLE pg_git.notes (
+CREATE TABLE pggit.notes (
     repo_id INTEGER REFERENCES repositories(id),
     object_hash TEXT NOT NULL,
     note TEXT NOT NULL,
@@ -12,57 +12,60 @@ CREATE TABLE pg_git.notes (
 );
 
 -- Stash support
-CREATE TABLE pg_git.stash (
+CREATE TABLE pggit.stash (
     repo_id INTEGER REFERENCES repositories(id),
     stash_id SERIAL,
-    tree_hash TEXT NOT NULL REFERENCES trees(hash),
-    parent_hash TEXT REFERENCES commits(hash),
+    tree_hash TEXT NOT NULL,
+    parent_hash TEXT,
     message TEXT NOT NULL,
     author TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, stash_id)
+    PRIMARY KEY (repo_id, stash_id),
+    FOREIGN KEY (repo_id, tree_hash) REFERENCES pggit.trees(repo_id, hash),
+    FOREIGN KEY (repo_id, parent_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
 -- Worktree support
-CREATE TABLE pg_git.worktrees (
+CREATE TABLE pggit.worktrees (
     repo_id INTEGER REFERENCES repositories(id),
     path TEXT NOT NULL,
     branch TEXT NOT NULL,
-    commit_hash TEXT NOT NULL REFERENCES commits(hash),
+    commit_hash TEXT NOT NULL,
     locked BOOLEAN DEFAULT FALSE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, path)
+    PRIMARY KEY (repo_id, path),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
 -- Command implementations
 
-CREATE OR REPLACE FUNCTION pg_git.add_note(
+CREATE OR REPLACE FUNCTION pggit.add_note(
     p_repo_id INTEGER,
     p_object_hash TEXT,
     p_note TEXT,
     p_author TEXT DEFAULT current_user
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.notes (repo_id, object_hash, note, author)
+    INSERT INTO pggit.notes (repo_id, object_hash, note, author)
     VALUES (p_repo_id, p_object_hash, p_note, p_author)
     ON CONFLICT (repo_id, object_hash) 
     DO UPDATE SET note = p_note, author = p_author;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.stash_save(
+CREATE OR REPLACE FUNCTION pggit.stash_save(
     p_repo_id INTEGER,
     p_message TEXT DEFAULT '',
     p_author TEXT DEFAULT current_user
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_tree_hash TEXT;
     v_stash_id INTEGER;
 BEGIN
     -- Create tree from current index
-    v_tree_hash := pg_git.create_tree_from_index(p_repo_id);
+    v_tree_hash := pggit.create_tree_from_index(p_repo_id);
     
-    INSERT INTO pg_git.stash (repo_id, tree_hash, parent_hash, message, author)
+    INSERT INTO pggit.stash (repo_id, tree_hash, parent_hash, message, author)
     VALUES (p_repo_id, v_tree_hash, 
             (SELECT commit_hash FROM refs WHERE name = 'HEAD'),
             p_message, p_author)
@@ -75,23 +78,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.stash_pop(
+CREATE OR REPLACE FUNCTION pggit.stash_pop(
     p_repo_id INTEGER,
     p_stash_id INTEGER DEFAULT NULL
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_stash RECORD;
 BEGIN
     -- Get most recent stash if no id provided
     IF p_stash_id IS NULL THEN
         SELECT * INTO v_stash
-        FROM pg_git.stash
+        FROM pggit.stash
         WHERE repo_id = p_repo_id
         ORDER BY stash_id DESC
         LIMIT 1;
     ELSE
         SELECT * INTO v_stash
-        FROM pg_git.stash
+        FROM pggit.stash
         WHERE repo_id = p_repo_id AND stash_id = p_stash_id;
     END IF;
     
@@ -102,23 +105,23 @@ BEGIN
     WHERE hash = v_stash.tree_hash;
     
     -- Remove stash
-    DELETE FROM pg_git.stash
+    DELETE FROM pggit.stash
     WHERE repo_id = p_repo_id AND stash_id = v_stash.stash_id;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.add_worktree(
+CREATE OR REPLACE FUNCTION pggit.add_worktree(
     p_repo_id INTEGER,
     p_path TEXT,
     p_branch TEXT,
     p_create_branch BOOLEAN DEFAULT FALSE
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_commit_hash TEXT;
 BEGIN
     -- Get or create branch
     IF p_create_branch THEN
-        PERFORM pg_git.create_branch(p_repo_id, p_branch);
+        PERFORM pggit.create_branch(p_repo_id, p_branch);
     END IF;
     
     SELECT commit_hash INTO v_commit_hash
@@ -128,13 +131,13 @@ BEGIN
         RAISE EXCEPTION 'Branch % not found', p_branch;
     END IF;
     
-    INSERT INTO pg_git.worktrees (repo_id, path, branch, commit_hash)
+    INSERT INTO pggit.worktrees (repo_id, path, branch, commit_hash)
     VALUES (p_repo_id, p_path, p_branch, v_commit_hash);
 END;
 $$ LANGUAGE plpgsql;
 
 -- Blame implementation
-CREATE OR REPLACE FUNCTION pg_git.blame(
+CREATE OR REPLACE FUNCTION pggit.blame(
     p_repo_id INTEGER,
     p_path TEXT,
     p_commit TEXT DEFAULT 'HEAD'
@@ -142,17 +145,17 @@ CREATE OR REPLACE FUNCTION pg_git.blame(
     line_number INTEGER,
     commit_hash TEXT,
     author TEXT,
-    timestamp TIMESTAMP WITH TIME ZONE,
+    "timestamp" TIMESTAMP WITH TIME ZONE,
     line_content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_commit_hash TEXT;
     v_blob_hash TEXT;
 BEGIN
-    -- Resolve commit
+    -- Resolve commit (qualify commit_hash to avoid clash with the OUT column)
     IF p_commit = 'HEAD' THEN
-        SELECT commit_hash INTO v_commit_hash
-        FROM refs WHERE name = 'HEAD';
+        SELECT r.commit_hash INTO v_commit_hash
+        FROM refs r WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
     ELSE
         v_commit_hash := p_commit;
     END IF;

--- a/sql/pgit-archive.sql
+++ b/sql/pgit-archive.sql
@@ -1,11 +1,11 @@
 -- Path: /sql/functions/019-archive.sql
 -- Archive functionality
 
-CREATE OR REPLACE FUNCTION pg_git.create_archive(
+CREATE OR REPLACE FUNCTION pggit.create_archive(
     p_repo_id INTEGER,
     p_tree_ish TEXT DEFAULT 'HEAD',
     p_format TEXT DEFAULT 'tar'
-) RETURNS BYTEA AS $$
+) RETURNS BYTEA SET search_path = pggit, public AS $$
 DECLARE
     v_tree_hash TEXT;
     v_archive BYTEA;

--- a/sql/pgit-bundle.sql
+++ b/sql/pgit-bundle.sql
@@ -1,28 +1,28 @@
 -- Path: /sql/functions/032-bundle.sql
 -- Bundle repository data for offline transfer
 
-CREATE TABLE pg_git.bundles (
+CREATE TABLE pggit.bundles (
     id SERIAL PRIMARY KEY,
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     description TEXT,
     prerequisites TEXT[] DEFAULT ARRAY[]::TEXT[],
-    references TEXT[] NOT NULL,
+    "references" TEXT[] NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE OR REPLACE FUNCTION pg_git.create_bundle(
+CREATE OR REPLACE FUNCTION pggit.create_bundle(
     p_repo_id INTEGER,
     p_name TEXT,
     p_refs TEXT[],
     p_description TEXT DEFAULT NULL
-) RETURNS BYTEA AS $$
+) RETURNS BYTEA SET search_path = pggit, public AS $$
 DECLARE
     v_bundle_data BYTEA;
     v_bundle_id INTEGER;
 BEGIN
     -- Create bundle record
-    INSERT INTO pg_git.bundles (repo_id, name, description, references)
+    INSERT INTO pggit.bundles (repo_id, name, description, "references")
     VALUES (p_repo_id, p_name, p_description, p_refs)
     RETURNING id INTO v_bundle_id;
 
@@ -84,13 +84,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.unbundle(
+CREATE OR REPLACE FUNCTION pggit.unbundle(
     p_repo_id INTEGER,
     p_bundle_data BYTEA
 ) RETURNS TABLE (
     type TEXT,
     hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_line RECORD;
 BEGIN

--- a/sql/pgit-control.sql
+++ b/sql/pgit-control.sql
@@ -2,6 +2,6 @@ comment = 'Git implementation in PostgreSQL'
 default_version = '0.4.0'
 module_pathname = '$libdir/pg_git'
 relocatable = false
-schema = pg_git
+schema = pggit
 requires = 'plpgsql'
 superuser = false

--- a/sql/pgit-diagnose.sql
+++ b/sql/pgit-diagnose.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/024-diagnose.sql
 -- Diagnostic information collection
 
-CREATE TABLE pg_git.diagnostic_reports (
+CREATE TABLE pggit.diagnostic_reports (
     id SERIAL PRIMARY KEY,
     repo_id INTEGER REFERENCES repositories(id),
     report_type TEXT NOT NULL,
@@ -9,9 +9,9 @@ CREATE TABLE pg_git.diagnostic_reports (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE OR REPLACE FUNCTION pg_git.collect_diagnostics(
+CREATE OR REPLACE FUNCTION pggit.collect_diagnostics(
     p_repo_id INTEGER
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_report_id INTEGER;
     v_report_data JSONB;
@@ -43,7 +43,7 @@ BEGIN
     -- Collect error info
     error_info AS (
         SELECT status, count(*) as count
-        FROM pg_git.verify_integrity(p_repo_id)
+        FROM pggit.verify_integrity(p_repo_id)
         GROUP BY status
     )
     SELECT jsonb_build_object(
@@ -53,7 +53,7 @@ BEGIN
         'errors', jsonb_agg(to_jsonb(error_info)),
         'configs', (
             SELECT jsonb_object_agg(key, value)
-            FROM pg_git.config
+            FROM pggit.config
             WHERE repo_id = p_repo_id
         )
     )
@@ -61,7 +61,7 @@ BEGIN
     FROM repo_info, size_info, perf_metrics, error_info;
 
     -- Store report
-    INSERT INTO pg_git.diagnostic_reports (repo_id, report_type, report_data)
+    INSERT INTO pggit.diagnostic_reports (repo_id, report_type, report_data)
     VALUES (p_repo_id, 'full', v_report_data)
     RETURNING id INTO v_report_id;
 
@@ -69,17 +69,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.get_diagnostic_report(
+CREATE OR REPLACE FUNCTION pggit.get_diagnostic_report(
     p_report_id INTEGER
 ) RETURNS TABLE (
     section TEXT,
     content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     WITH report AS (
         SELECT report_data
-        FROM pg_git.diagnostic_reports
+        FROM pggit.diagnostic_reports
         WHERE id = p_report_id
     )
     SELECT 'Repository Info' as section,

--- a/sql/pgit-extras.sql
+++ b/sql/pgit-extras.sql
@@ -2,10 +2,10 @@
 -- Additional Git commands and utilities
 
 -- Cherry-pick implementation
-CREATE OR REPLACE FUNCTION pg_git.cherry_pick(
+CREATE OR REPLACE FUNCTION pggit.cherry_pick(
     p_repo_id INTEGER,
     p_commit_hash TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_tree_hash TEXT;
     v_new_commit TEXT;
@@ -18,7 +18,7 @@ BEGIN
     FROM commits WHERE hash = p_commit_hash;
     
     -- Create new commit with same tree
-    v_new_commit := pg_git.create_commit(
+    v_new_commit := pggit.create_commit(
         p_repo_id,
         v_tree_hash,
         (SELECT commit_hash FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD'),
@@ -36,10 +36,10 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Revert implementation
-CREATE OR REPLACE FUNCTION pg_git.revert(
+CREATE OR REPLACE FUNCTION pggit.revert(
     p_repo_id INTEGER,
     p_commit_hash TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_parent_tree TEXT;
     v_commit_tree TEXT;
@@ -55,10 +55,10 @@ BEGIN
     WHERE c.repo_id = p_repo_id AND hash = p_commit_hash;
     
     -- Create inverse diff
-    v_new_tree := pg_git.apply_inverse_diff(v_parent_tree, v_commit_tree);
+    v_new_tree := pggit.apply_inverse_diff(v_parent_tree, v_commit_tree);
     
     -- Create revert commit
-    v_new_commit := pg_git.create_commit(
+    v_new_commit := pggit.create_commit(
         p_repo_id,
         v_new_tree,
         (SELECT commit_hash FROM refs WHERE repo_id = p_repo_id AND name = 'HEAD'),
@@ -76,7 +76,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Bisect implementation
-CREATE TABLE pg_git.bisect_state (
+CREATE TABLE pggit.bisect_state (
     repo_id INTEGER REFERENCES repositories(id),
     start_commit TEXT NOT NULL,
     good_commits TEXT[] DEFAULT ARRAY[]::TEXT[],
@@ -85,16 +85,16 @@ CREATE TABLE pg_git.bisect_state (
     PRIMARY KEY (repo_id)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.bisect_start(
+CREATE OR REPLACE FUNCTION pggit.bisect_start(
     p_repo_id INTEGER,
     p_bad_commit TEXT,
     p_good_commit TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_mid_commit TEXT;
 BEGIN
     -- Initialize bisect state
-    INSERT INTO pg_git.bisect_state (repo_id, start_commit, good_commits, bad_commits)
+    INSERT INTO pggit.bisect_state (repo_id, start_commit, good_commits, bad_commits)
     VALUES (p_repo_id, p_bad_commit, ARRAY[p_good_commit], ARRAY[p_bad_commit])
     ON CONFLICT (repo_id) DO UPDATE
     SET start_commit = p_bad_commit,
@@ -106,12 +106,12 @@ BEGIN
     FROM (
         SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
                COUNT(*) OVER () as total
-        FROM pg_git.rev_list(p_bad_commit, ARRAY[p_good_commit])
+        FROM pggit.rev_list(p_bad_commit, ARRAY[p_good_commit])
     ) commits
     WHERE rn = total/2;
     
     -- Update current commit
-    UPDATE pg_git.bisect_state
+    UPDATE pggit.bisect_state
     SET current_commit = v_mid_commit
     WHERE repo_id = p_repo_id;
     
@@ -119,20 +119,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.bisect_good(
+CREATE OR REPLACE FUNCTION pggit.bisect_good(
     p_repo_id INTEGER
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_current TEXT;
     v_next TEXT;
 BEGIN
     -- Get current state
     SELECT current_commit INTO v_current
-    FROM pg_git.bisect_state
+    FROM pggit.bisect_state
     WHERE repo_id = p_repo_id;
     
     -- Add to good commits
-    UPDATE pg_git.bisect_state
+    UPDATE pggit.bisect_state
     SET good_commits = array_append(good_commits, v_current)
     WHERE repo_id = p_repo_id;
     
@@ -141,15 +141,15 @@ BEGIN
     FROM (
         SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
                COUNT(*) OVER () as total
-        FROM pg_git.rev_list(
-            (SELECT bad_commits[1] FROM pg_git.bisect_state WHERE repo_id = p_repo_id),
-            (SELECT good_commits FROM pg_git.bisect_state WHERE repo_id = p_repo_id)
+        FROM pggit.rev_list(
+            (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
+            (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )
     ) commits
     WHERE rn = total/2;
     
     -- Update current commit
-    UPDATE pg_git.bisect_state
+    UPDATE pggit.bisect_state
     SET current_commit = v_next
     WHERE repo_id = p_repo_id;
     
@@ -157,20 +157,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.bisect_bad(
+CREATE OR REPLACE FUNCTION pggit.bisect_bad(
     p_repo_id INTEGER
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_current TEXT;
     v_next TEXT;
 BEGIN
     -- Get current state
     SELECT current_commit INTO v_current
-    FROM pg_git.bisect_state
+    FROM pggit.bisect_state
     WHERE repo_id = p_repo_id;
     
     -- Add to bad commits
-    UPDATE pg_git.bisect_state
+    UPDATE pggit.bisect_state
     SET bad_commits = array_append(bad_commits, v_current)
     WHERE repo_id = p_repo_id;
     
@@ -179,15 +179,15 @@ BEGIN
     FROM (
         SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
                COUNT(*) OVER () as total
-        FROM pg_git.rev_list(
-            (SELECT bad_commits[1] FROM pg_git.bisect_state WHERE repo_id = p_repo_id),
-            (SELECT good_commits FROM pg_git.bisect_state WHERE repo_id = p_repo_id)
+        FROM pggit.rev_list(
+            (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
+            (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )
     ) commits
     WHERE rn = total/2;
     
     -- Update current commit
-    UPDATE pg_git.bisect_state
+    UPDATE pggit.bisect_state
     SET current_commit = v_next
     WHERE repo_id = p_repo_id;
     
@@ -195,17 +195,17 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.bisect_reset(
+CREATE OR REPLACE FUNCTION pggit.bisect_reset(
     p_repo_id INTEGER
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    DELETE FROM pg_git.bisect_state
+    DELETE FROM pggit.bisect_state
     WHERE repo_id = p_repo_id;
 END;
 $$ LANGUAGE plpgsql;
 
 -- Grep implementation
-CREATE OR REPLACE FUNCTION pg_git.grep(
+CREATE OR REPLACE FUNCTION pggit.grep(
     p_repo_id INTEGER,
     p_pattern TEXT,
     p_commit TEXT DEFAULT 'HEAD',
@@ -214,7 +214,7 @@ CREATE OR REPLACE FUNCTION pg_git.grep(
     file_path TEXT,
     line_number INTEGER,
     line_content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_commit_hash TEXT;
 BEGIN
@@ -237,7 +237,7 @@ BEGIN
     )
     SELECT f.path,
            s.line_number,
-           s.line_content
+           s.lines[s.line_number]
     FROM files f,
     LATERAL (
         SELECT generate_subscripts(regexp_split_to_array(encode(f.content, 'escape'), E'\n'), 1) as line_number,

--- a/sql/pgit-instaweb.sql
+++ b/sql/pgit-instaweb.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/028-instaweb.sql
 -- Instaweb functionality for repository browsing
 
-CREATE TABLE pg_git.instaweb_config (
+CREATE TABLE pggit.instaweb_config (
     repo_id INTEGER REFERENCES repositories(id),
     port INTEGER NOT NULL DEFAULT 1234,
     host TEXT NOT NULL DEFAULT 'localhost',
@@ -11,7 +11,7 @@ CREATE TABLE pg_git.instaweb_config (
     PRIMARY KEY (repo_id)
 );
 
-CREATE TABLE pg_git.instaweb_users (
+CREATE TABLE pggit.instaweb_users (
     repo_id INTEGER REFERENCES repositories(id),
     username TEXT NOT NULL,
     password_hash TEXT NOT NULL,
@@ -20,19 +20,19 @@ CREATE TABLE pg_git.instaweb_users (
     PRIMARY KEY (repo_id, username)
 );
 
-CREATE TABLE pg_git.instaweb_sessions (
+CREATE TABLE pggit.instaweb_sessions (
     repo_id INTEGER REFERENCES repositories(id),
     session_id TEXT PRIMARY KEY,
     username TEXT NOT NULL,
     started_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
-    FOREIGN KEY (repo_id, username) REFERENCES pg_git.instaweb_users(repo_id, username)
+    FOREIGN KEY (repo_id, username) REFERENCES pggit.instaweb_users(repo_id, username)
 );
 
 -- HTML Template for repository view
-CREATE OR REPLACE FUNCTION pg_git.get_instaweb_template(
+CREATE OR REPLACE FUNCTION pggit.get_instaweb_template(
     p_repo_id INTEGER
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 BEGIN
     RETURN '
 <!DOCTYPE html>
@@ -65,10 +65,10 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Generate repository view
-CREATE OR REPLACE FUNCTION pg_git.generate_repo_view(
+CREATE OR REPLACE FUNCTION pggit.generate_repo_view(
     p_repo_id INTEGER,
     p_ref TEXT DEFAULT 'HEAD'
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_template TEXT;
     v_content TEXT;
@@ -84,7 +84,7 @@ BEGIN
                c.message,
                c.author,
                c.timestamp
-        FROM pg_git.get_log(p_repo_id, 10) c
+        FROM pggit.get_log(p_repo_id, 10) c
     )
     SELECT string_agg(
         format(
@@ -104,7 +104,7 @@ BEGIN
     FROM commit_list;
 
     -- Get template and replace placeholders
-    v_template := pg_git.get_instaweb_template(p_repo_id);
+    v_template := pggit.get_instaweb_template(p_repo_id);
     v_template := replace(v_template, '{{repo_name}}', v_repo_name);
     v_template := replace(v_template, '{{content}}', v_content);
 
@@ -113,14 +113,14 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Start instaweb server
-CREATE OR REPLACE FUNCTION pg_git.start_instaweb(
+CREATE OR REPLACE FUNCTION pggit.start_instaweb(
     p_repo_id INTEGER,
     p_port INTEGER DEFAULT 1234,
     p_host TEXT DEFAULT 'localhost',
     p_auth_required BOOLEAN DEFAULT FALSE
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.instaweb_config (
+    INSERT INTO pggit.instaweb_config (
         repo_id, port, host, auth_required
     ) VALUES (
         p_repo_id, p_port, p_host, p_auth_required
@@ -137,15 +137,15 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Stop instaweb server
-CREATE OR REPLACE FUNCTION pg_git.stop_instaweb(
+CREATE OR REPLACE FUNCTION pggit.stop_instaweb(
     p_repo_id INTEGER
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    DELETE FROM pg_git.instaweb_config
+    DELETE FROM pggit.instaweb_config
     WHERE repo_id = p_repo_id;
     
     -- Clean up sessions
-    DELETE FROM pg_git.instaweb_sessions
+    DELETE FROM pggit.instaweb_sessions
     WHERE repo_id = p_repo_id;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/pgit-merge-tree.sql
+++ b/sql/pgit-merge-tree.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/022-merge-tree.sql
 -- Enhanced merge tree operations
 
-CREATE OR REPLACE FUNCTION pg_git.merge_trees(
+CREATE OR REPLACE FUNCTION pggit.merge_trees(
     p_base_tree TEXT,
     p_ours_tree TEXT,
     p_theirs_tree TEXT
@@ -11,7 +11,7 @@ CREATE OR REPLACE FUNCTION pg_git.merge_trees(
     mode TEXT,
     hash TEXT,
     status TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     -- Get all paths from all trees
     RETURN QUERY
@@ -85,4 +85,8 @@ BEGIN
                ELSE 'clean'
            END as status
     FROM analysis
-    WHERE NOT (ours_hash = theirs_hash
+    -- Only report paths that actually differ across base/ours/theirs.
+    WHERE NOT (ours_hash IS NOT DISTINCT FROM theirs_hash
+               AND ours_hash IS NOT DISTINCT FROM base_hash);
+END;
+$$ LANGUAGE plpgsql;

--- a/sql/pgit-pack-refs.sql
+++ b/sql/pgit-pack-refs.sql
@@ -1,32 +1,35 @@
 -- Path: /sql/functions/029-pack-refs.sql
 -- Pack refs for efficient repository access
 
-CREATE TABLE pg_git.packed_refs (
+CREATE TABLE pggit.packed_refs (
     repo_id INTEGER REFERENCES repositories(id),
     ref_name TEXT NOT NULL,
-    commit_hash TEXT NOT NULL REFERENCES commits(hash),
-    peeled_hash TEXT REFERENCES commits(hash),
+    commit_hash TEXT NOT NULL,
+    peeled_hash TEXT,
     packed_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, ref_name)
+    PRIMARY KEY (repo_id, ref_name),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash),
+    FOREIGN KEY (repo_id, peeled_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.pack_refs(
+CREATE OR REPLACE FUNCTION pggit.pack_refs(
     p_repo_id INTEGER,
     p_all BOOLEAN DEFAULT FALSE
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_count INTEGER;
 BEGIN
     -- Pack all refs or just frequently accessed ones
-    INSERT INTO pg_git.packed_refs (repo_id, ref_name, commit_hash, peeled_hash)
+    INSERT INTO pggit.packed_refs (repo_id, ref_name, commit_hash, peeled_hash)
     SELECT r.repo_id, r.name, r.commit_hash,
            CASE 
                WHEN t.target_hash IS NOT NULL THEN t.target_hash
                ELSE NULL
            END
     FROM refs r
-    LEFT JOIN pg_git.tags t ON r.commit_hash = t.target_hash
+    LEFT JOIN pggit.tags t ON r.commit_hash = t.target_hash
     WHERE r.repo_id = p_repo_id
+    AND r.name <> 'HEAD'
     AND (p_all OR r.name IN (
         SELECT name 
         FROM refs 
@@ -44,14 +47,14 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.unpack_refs(
+CREATE OR REPLACE FUNCTION pggit.unpack_refs(
     p_repo_id INTEGER,
     p_ref_pattern TEXT DEFAULT NULL
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_count INTEGER;
 BEGIN
-    DELETE FROM pg_git.packed_refs
+    DELETE FROM pggit.packed_refs
     WHERE repo_id = p_repo_id
     AND (p_ref_pattern IS NULL OR ref_name LIKE p_ref_pattern);
     
@@ -60,13 +63,13 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.verify_packed_refs(
+CREATE OR REPLACE FUNCTION pggit.verify_packed_refs(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     ref_name TEXT,
     is_valid BOOLEAN,
     error_message TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     SELECT pr.ref_name,
@@ -82,7 +85,7 @@ BEGIN
                     NOT EXISTS (SELECT 1 FROM commits WHERE hash = pr.peeled_hash) THEN 'Invalid peeled hash'
                ELSE 'Valid'
            END as error_message
-    FROM pg_git.packed_refs pr
+    FROM pggit.packed_refs pr
     JOIN refs r ON r.name = pr.ref_name
     WHERE pr.repo_id = p_repo_id;
 END;

--- a/sql/pgit-plumbing.sql
+++ b/sql/pgit-plumbing.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/017-plumbing.sql
 -- Git plumbing commands implementation
 
-CREATE OR REPLACE FUNCTION pg_git.cat_file(
+CREATE OR REPLACE FUNCTION pggit.cat_file(
     p_repo_id INTEGER,
     p_hash TEXT,
     p_type TEXT DEFAULT NULL
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION pg_git.cat_file(
     object_type TEXT,
     size BIGINT,
     content TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     -- Try blobs
     RETURN QUERY
@@ -41,24 +41,24 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.hash_object(
+CREATE OR REPLACE FUNCTION pggit.hash_object(
     p_repo_id INTEGER,
     p_content BYTEA,
     p_type TEXT DEFAULT 'blob'
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 BEGIN
     CASE p_type
         WHEN 'blob' THEN
-            RETURN pg_git.create_blob(p_repo_id, p_content);
+            RETURN pggit.create_blob(p_repo_id, p_content);
         WHEN 'tree' THEN
-            RETURN pg_git.create_tree(p_repo_id, p_content::TEXT::jsonb);
+            RETURN pggit.create_tree(p_repo_id, p_content::TEXT::jsonb);
         ELSE
             RAISE EXCEPTION 'Unsupported object type: %', p_type;
     END CASE;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.ls_tree(
+CREATE OR REPLACE FUNCTION pggit.ls_tree(
     p_repo_id INTEGER,
     p_tree_hash TEXT,
     p_recursive BOOLEAN DEFAULT FALSE
@@ -67,7 +67,7 @@ CREATE OR REPLACE FUNCTION pg_git.ls_tree(
     type TEXT,
     hash TEXT,
     path TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     IF NOT p_recursive THEN
         RETURN QUERY
@@ -112,23 +112,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.merge_base(
+CREATE OR REPLACE FUNCTION pggit.merge_base(
     p_repo_id INTEGER,
     p_commit1 TEXT,
     p_commit2 TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
     -- Reuse existing merge base finding function
-    SELECT pg_git.find_merge_base(p_repo_id, p_commit1, p_commit2);
+    SELECT pggit.find_merge_base(p_repo_id, p_commit1, p_commit2);
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.rev_list(
+CREATE OR REPLACE FUNCTION pggit.rev_list(
     p_repo_id INTEGER,
     p_start_commit TEXT,
     p_exclude_commits TEXT[] DEFAULT ARRAY[]::TEXT[]
 ) RETURNS TABLE (
     hash TEXT,
     commit_data JSONB
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     WITH RECURSIVE commit_list AS (

--- a/sql/pgit-repack.sql
+++ b/sql/pgit-repack.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/030-repack.sql
 -- Repack objects for efficient storage
 
-CREATE TABLE pg_git.pack_files (
+CREATE TABLE pggit.pack_files (
     id SERIAL PRIMARY KEY,
     repo_id INTEGER REFERENCES repositories(id),
     pack_hash TEXT NOT NULL,
@@ -10,23 +10,23 @@ CREATE TABLE pg_git.pack_files (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE pg_git.packed_objects (
-    pack_id INTEGER REFERENCES pg_git.pack_files(id),
+CREATE TABLE pggit.packed_objects (
+    pack_id INTEGER REFERENCES pggit.pack_files(id),
     object_hash TEXT NOT NULL,
-    offset INTEGER NOT NULL,
+    "offset" INTEGER NOT NULL,
     size INTEGER NOT NULL,
     type TEXT NOT NULL,
     delta_base TEXT,
     PRIMARY KEY (pack_id, object_hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.repack(
+CREATE OR REPLACE FUNCTION pggit.repack(
     p_repo_id INTEGER,
     p_aggressive BOOLEAN DEFAULT FALSE
 ) RETURNS TABLE (
     objects_packed INTEGER,
     space_saved BIGINT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_pack_id INTEGER;
     v_old_size BIGINT;
@@ -45,9 +45,9 @@ BEGIN
     ) objects;
 
     -- Create new pack
-    INSERT INTO pg_git.pack_files (repo_id, pack_hash, object_count, size_bytes)
+    INSERT INTO pggit.pack_files (repo_id, pack_hash, object_count, size_bytes)
     SELECT p_repo_id,
-           encode(sha256(string_agg(hash, '')), 'hex'),
+           encode(sha256(convert_to(string_agg(hash, ''), 'UTF8')), 'hex'),
            count(*),
            sum(
                CASE 
@@ -67,8 +67,8 @@ BEGIN
 
     -- Pack objects with delta compression if aggressive
     IF p_aggressive THEN
-        INSERT INTO pg_git.packed_objects (
-            pack_id, object_hash, offset, size, type, delta_base
+        INSERT INTO pggit.packed_objects (
+            pack_id, object_hash, "offset", size, type, delta_base
         )
         WITH object_analysis AS (
             SELECT hash,
@@ -80,7 +80,7 @@ BEGIN
                        WHEN content IS NOT NULL THEN content
                        ELSE entries::text::bytea
                    END as data,
-                   row_number() OVER (ORDER BY hash) as offset
+                   row_number() OVER (ORDER BY hash) as "offset"
             FROM (
                 SELECT hash, content, NULL::jsonb as entries 
                 FROM blobs
@@ -92,7 +92,7 @@ BEGIN
         delta_candidates AS (
             SELECT a1.hash as obj_hash,
                    a1.type,
-                   a1.offset,
+                   a1."offset",
                    octet_length(a1.data) as size,
                    a2.hash as base_hash
             FROM object_analysis a1
@@ -103,14 +103,14 @@ BEGIN
         )
         SELECT v_pack_id,
                obj_hash,
-               offset,
+               "offset",
                size,
                type,
                base_hash
         FROM delta_candidates;
     ELSE
-        INSERT INTO pg_git.packed_objects (
-            pack_id, object_hash, offset, size, type
+        INSERT INTO pggit.packed_objects (
+            pack_id, object_hash, "offset", size, type
         )
         SELECT v_pack_id,
                hash,
@@ -138,20 +138,20 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.unpack(
+CREATE OR REPLACE FUNCTION pggit.unpack(
     p_repo_id INTEGER,
     p_pack_id INTEGER DEFAULT NULL
-) RETURNS INTEGER AS $$
+) RETURNS INTEGER SET search_path = pggit, public AS $$
 DECLARE
     v_count INTEGER;
 BEGIN
-    DELETE FROM pg_git.packed_objects po
-    USING pg_git.pack_files pf
+    DELETE FROM pggit.packed_objects po
+    USING pggit.pack_files pf
     WHERE po.pack_id = pf.id
     AND pf.repo_id = p_repo_id
     AND (p_pack_id IS NULL OR pf.id = p_pack_id);
     
-    DELETE FROM pg_git.pack_files
+    DELETE FROM pggit.pack_files
     WHERE repo_id = p_repo_id
     AND (p_pack_id IS NULL OR id = p_pack_id);
     

--- a/sql/pgit-replace.sql
+++ b/sql/pgit-replace.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/031-replace.sql
 -- Replace object references
 
-CREATE TABLE pg_git.replacements (
+CREATE TABLE pggit.replacements (
     repo_id INTEGER REFERENCES repositories(id),
     original_hash TEXT NOT NULL,
     replacement_hash TEXT NOT NULL,
@@ -10,59 +10,59 @@ CREATE TABLE pg_git.replacements (
     PRIMARY KEY (repo_id, original_hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.replace(
+CREATE OR REPLACE FUNCTION pggit.replace(
     p_repo_id INTEGER,
     p_original TEXT,
     p_replacement TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_type TEXT;
 BEGIN
     -- Determine object type
-    IF EXISTS (SELECT 1 FROM commits WHERE hash = p_original) THEN
+    IF EXISTS (SELECT 1 FROM commits WHERE repo_id = p_repo_id AND hash = p_original) THEN
         v_type := 'commit';
-    ELSIF EXISTS (SELECT 1 FROM trees WHERE hash = p_original) THEN
+    ELSIF EXISTS (SELECT 1 FROM trees WHERE repo_id = p_repo_id AND hash = p_original) THEN
         v_type := 'tree';
-    ELSIF EXISTS (SELECT 1 FROM blobs WHERE hash = p_original) THEN
+    ELSIF EXISTS (SELECT 1 FROM blobs WHERE repo_id = p_repo_id AND hash = p_original) THEN
         v_type := 'blob';
     ELSE
         RAISE EXCEPTION 'Original object not found';
     END IF;
 
-    -- Verify replacement exists and is same type
+    -- Verify replacement exists and is the same object type
     IF NOT EXISTS (
-        CASE v_type
-            WHEN 'commit' THEN SELECT 1 FROM commits WHERE hash = p_replacement
-            WHEN 'tree' THEN SELECT 1 FROM trees WHERE hash = p_replacement
-            WHEN 'blob' THEN SELECT 1 FROM blobs WHERE hash = p_replacement
-        END
+        SELECT 1 FROM commits WHERE v_type = 'commit' AND repo_id = p_repo_id AND hash = p_replacement
+        UNION ALL
+        SELECT 1 FROM trees   WHERE v_type = 'tree'   AND repo_id = p_repo_id AND hash = p_replacement
+        UNION ALL
+        SELECT 1 FROM blobs   WHERE v_type = 'blob'   AND repo_id = p_repo_id AND hash = p_replacement
     ) THEN
         RAISE EXCEPTION 'Replacement object not found or wrong type';
     END IF;
 
-    INSERT INTO pg_git.replacements (repo_id, original_hash, replacement_hash, type)
+    INSERT INTO pggit.replacements (repo_id, original_hash, replacement_hash, type)
     VALUES (p_repo_id, p_original, p_replacement, v_type)
     ON CONFLICT (repo_id, original_hash) 
     DO UPDATE SET replacement_hash = p_replacement;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.get_replaced_hash(
+CREATE OR REPLACE FUNCTION pggit.get_replaced_hash(
     p_repo_id INTEGER,
     p_hash TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
     SELECT COALESCE(replacement_hash, p_hash)
-    FROM pg_git.replacements
+    FROM pggit.replacements
     WHERE repo_id = p_repo_id
     AND original_hash = p_hash;
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.remove_replace(
+CREATE OR REPLACE FUNCTION pggit.remove_replace(
     p_repo_id INTEGER,
     p_original TEXT
-) RETURNS BOOLEAN AS $$
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
     WITH deleted AS (
-        DELETE FROM pg_git.replacements
+        DELETE FROM pggit.replacements
         WHERE repo_id = p_repo_id
         AND original_hash = p_original
         RETURNING 1
@@ -70,16 +70,16 @@ CREATE OR REPLACE FUNCTION pg_git.remove_replace(
     SELECT EXISTS (SELECT 1 FROM deleted);
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.list_replace(
+CREATE OR REPLACE FUNCTION pggit.list_replace(
     p_repo_id INTEGER
 ) RETURNS TABLE (
     original_hash TEXT,
     replacement_hash TEXT,
     type TEXT,
     created_at TIMESTAMP WITH TIME ZONE
-) AS $$
+) SET search_path = pggit, public AS $$
     SELECT original_hash, replacement_hash, type, created_at
-    FROM pg_git.replacements
+    FROM pggit.replacements
     WHERE repo_id = p_repo_id
     ORDER BY created_at DESC;
 $$ LANGUAGE sql;

--- a/sql/pgit-rerere.sql
+++ b/sql/pgit-rerere.sql
@@ -1,21 +1,22 @@
 -- Path: /sql/functions/023-rerere.sql
 -- Reuse recorded resolution
 
-CREATE TABLE pg_git.rerere_cache (
+CREATE TABLE pggit.rerere_cache (
     repo_id INTEGER REFERENCES repositories(id),
     conflict_hash TEXT NOT NULL,
     path TEXT NOT NULL,
-    resolution_blob_hash TEXT REFERENCES blobs(hash),
+    resolution_blob_hash TEXT,
     recorded_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     used_count INTEGER DEFAULT 0,
     last_used TIMESTAMP WITH TIME ZONE,
-    PRIMARY KEY (repo_id, conflict_hash, path)
+    PRIMARY KEY (repo_id, conflict_hash, path),
+    FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.hash_conflict(
+CREATE OR REPLACE FUNCTION pggit.hash_conflict(
     p_our_blob TEXT,
     p_their_blob TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
     SELECT encode(sha256(
         COALESCE(o.content, ''::BYTEA) || 
         COALESCE(t.content, ''::BYTEA)
@@ -26,19 +27,19 @@ CREATE OR REPLACE FUNCTION pg_git.hash_conflict(
     AND t.hash = p_their_blob;
 $$ LANGUAGE sql;
 
-CREATE OR REPLACE FUNCTION pg_git.record_resolution(
+CREATE OR REPLACE FUNCTION pggit.record_resolution(
     p_repo_id INTEGER,
     p_path TEXT,
     p_our_blob TEXT,
     p_their_blob TEXT,
     p_resolution_blob TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_conflict_hash TEXT;
 BEGIN
-    v_conflict_hash := pg_git.hash_conflict(p_our_blob, p_their_blob);
+    v_conflict_hash := pggit.hash_conflict(p_our_blob, p_their_blob);
     
-    INSERT INTO pg_git.rerere_cache (
+    INSERT INTO pggit.rerere_cache (
         repo_id, conflict_hash, path, resolution_blob_hash
     ) VALUES (
         p_repo_id, v_conflict_hash, p_path, p_resolution_blob
@@ -50,19 +51,19 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.find_resolution(
+CREATE OR REPLACE FUNCTION pggit.find_resolution(
     p_repo_id INTEGER,
     p_path TEXT,
     p_our_blob TEXT,
     p_their_blob TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_conflict_hash TEXT;
     v_resolution_hash TEXT;
 BEGIN
-    v_conflict_hash := pg_git.hash_conflict(p_our_blob, p_their_blob);
+    v_conflict_hash := pggit.hash_conflict(p_our_blob, p_their_blob);
     
-    UPDATE pg_git.rerere_cache
+    UPDATE pggit.rerere_cache
     SET used_count = used_count + 1,
         last_used = CURRENT_TIMESTAMP
     WHERE repo_id = p_repo_id
@@ -74,11 +75,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.clear_rerere_cache(
+CREATE OR REPLACE FUNCTION pggit.clear_rerere_cache(
     p_repo_id INTEGER,
     p_older_than INTERVAL DEFAULT NULL
-) RETURNS INTEGER AS $$
-    DELETE FROM pg_git.rerere_cache
+) RETURNS INTEGER SET search_path = pggit, public AS $$
+    DELETE FROM pggit.rerere_cache
     WHERE repo_id = p_repo_id
     AND (
         p_older_than IS NULL OR

--- a/sql/pgit-sparse.sql
+++ b/sql/pgit-sparse.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/021-sparse-checkout.sql
 -- Sparse checkout functionality
 
-CREATE TABLE pg_git.sparse_patterns (
+CREATE TABLE pggit.sparse_patterns (
     repo_id INTEGER REFERENCES repositories(id),
     pattern TEXT NOT NULL,
     is_negative BOOLEAN DEFAULT FALSE,
@@ -9,17 +9,17 @@ CREATE TABLE pg_git.sparse_patterns (
     PRIMARY KEY (repo_id, pattern)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.sparse_checkout_set(
+CREATE OR REPLACE FUNCTION pggit.sparse_checkout_set(
     p_repo_id INTEGER,
     p_patterns TEXT[]
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
     -- Clear existing patterns
-    DELETE FROM pg_git.sparse_patterns
+    DELETE FROM pggit.sparse_patterns
     WHERE repo_id = p_repo_id;
     
     -- Add new patterns
-    INSERT INTO pg_git.sparse_patterns (repo_id, pattern, is_negative)
+    INSERT INTO pggit.sparse_patterns (repo_id, pattern, is_negative)
     SELECT p_repo_id,
            pattern,
            pattern LIKE '!%'
@@ -27,12 +27,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.sparse_checkout_add(
+CREATE OR REPLACE FUNCTION pggit.sparse_checkout_add(
     p_repo_id INTEGER,
     p_patterns TEXT[]
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.sparse_patterns (repo_id, pattern, is_negative)
+    INSERT INTO pggit.sparse_patterns (repo_id, pattern, is_negative)
     SELECT p_repo_id,
            pattern,
            pattern LIKE '!%'
@@ -41,10 +41,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.is_path_in_sparse_checkout(
+CREATE OR REPLACE FUNCTION pggit.is_path_in_sparse_checkout(
     p_repo_id INTEGER,
     p_path TEXT
-) RETURNS BOOLEAN AS $$
+) RETURNS BOOLEAN SET search_path = pggit, public AS $$
 DECLARE
     v_result BOOLEAN;
 BEGIN
@@ -54,7 +54,7 @@ BEGIN
                    replace(pattern, '!', ''),
                    '*', '%'
                ) as matches
-        FROM pg_git.sparse_patterns
+        FROM pggit.sparse_patterns
         WHERE repo_id = p_repo_id
         ORDER BY is_negative, length(pattern) DESC
     )
@@ -76,13 +76,13 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Override tree functions to respect sparse checkout
-CREATE OR REPLACE FUNCTION pg_git.get_tree_files(
+CREATE OR REPLACE FUNCTION pggit.get_tree_files(
     p_repo_id INTEGER,
     p_tree_hash TEXT
 ) RETURNS TABLE (
     path TEXT,
     blob_hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     WITH RECURSIVE tree_files AS (
@@ -106,6 +106,6 @@ BEGIN
     SELECT tf.path, tf.hash
     FROM tree_files tf
     WHERE tf.type = 'blob'
-    AND pg_git.is_path_in_sparse_checkout(p_repo_id, tf.path);
+    AND pggit.is_path_in_sparse_checkout(p_repo_id, tf.path);
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/pgit-submodule.sql
+++ b/sql/pgit-submodule.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/020-submodule.sql
 -- Submodule support
 
-CREATE TABLE pg_git.submodules (
+CREATE TABLE pggit.submodules (
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     path TEXT NOT NULL,
@@ -11,12 +11,12 @@ CREATE TABLE pg_git.submodules (
     PRIMARY KEY (repo_id, path)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.submodule_add(
+CREATE OR REPLACE FUNCTION pggit.submodule_add(
     p_repo_id INTEGER,
     p_repository_url TEXT,
     p_path TEXT,
     p_name TEXT DEFAULT NULL
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_name TEXT;
     v_commit_hash TEXT;
@@ -25,17 +25,17 @@ BEGIN
     v_name := COALESCE(p_name, regexp_replace(p_path, '.*/', ''));
     
     -- Clone submodule
-    v_commit_hash := pg_git.clone(p_repository_url, v_name, p_path);
+    v_commit_hash := pggit.clone(p_repository_url, v_name, p_path);
     
     -- Register submodule
-    INSERT INTO pg_git.submodules (repo_id, name, path, url, commit_hash)
+    INSERT INTO pggit.submodules (repo_id, name, path, url, commit_hash)
     VALUES (p_repo_id, v_name, p_path, p_repository_url, v_commit_hash);
     
     RETURN v_commit_hash;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.submodule_update(
+CREATE OR REPLACE FUNCTION pggit.submodule_update(
     p_repo_id INTEGER,
     p_path TEXT DEFAULT NULL,
     p_recursive BOOLEAN DEFAULT FALSE
@@ -43,19 +43,18 @@ CREATE OR REPLACE FUNCTION pg_git.submodule_update(
     submodule_path TEXT,
     old_commit TEXT,
     new_commit TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 BEGIN
     RETURN QUERY
     WITH updated AS (
         SELECT s.path,
                s.commit_hash as old_commit,
-               pg_git.pull(s.repo_id, 'origin', s.branch) as new_commit
-        FROM pg_git.submodules s
+               pggit.pull(s.repo_id, 'origin', s.branch) as new_commit
+        FROM pggit.submodules s
         WHERE s.repo_id = p_repo_id
         AND (p_path IS NULL OR s.path = p_path)
-        RETURNING *
     )
-    UPDATE pg_git.submodules s
+    UPDATE pggit.submodules s
     SET commit_hash = u.new_commit
     FROM updated u
     WHERE s.repo_id = p_repo_id AND s.path = u.path
@@ -64,30 +63,30 @@ BEGIN
     -- Handle recursive update
     IF p_recursive THEN
         RETURN QUERY
-        SELECT * FROM pg_git.submodule_update_recursive(p_repo_id, p_path);
+        SELECT * FROM pggit.submodule_update_recursive(p_repo_id, p_path);
     END IF;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.submodule_update_recursive(
+CREATE OR REPLACE FUNCTION pggit.submodule_update_recursive(
     p_repo_id INTEGER,
     p_path TEXT DEFAULT NULL
 ) RETURNS TABLE (
     submodule_path TEXT,
     old_commit TEXT,
     new_commit TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_submodule RECORD;
 BEGIN
     FOR v_submodule IN
         SELECT s.* 
-        FROM pg_git.submodules s
+        FROM pggit.submodules s
         WHERE s.repo_id = p_repo_id
         AND (p_path IS NULL OR s.path = p_path)
     LOOP
         RETURN QUERY
-        SELECT * FROM pg_git.submodule_update(v_submodule.repo_id, NULL, TRUE);
+        SELECT * FROM pggit.submodule_update(v_submodule.repo_id, NULL, TRUE);
     END LOOP;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/pgit-update.sql
+++ b/sql/pgit-update.sql
@@ -5,7 +5,7 @@
 ALTER EXTENSION pg_git UPDATE TO '0.2.0';
 
 -- Add tags support
-CREATE TABLE pg_git.tags (
+CREATE TABLE pggit.tags (
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     target_hash TEXT NOT NULL,
@@ -16,7 +16,7 @@ CREATE TABLE pg_git.tags (
 );
 
 -- Add remote support
-CREATE TABLE pg_git.remotes (
+CREATE TABLE pggit.remotes (
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     url TEXT NOT NULL,
@@ -24,14 +24,14 @@ CREATE TABLE pg_git.remotes (
     PRIMARY KEY (repo_id, name)
 );
 
-CREATE TABLE pg_git.remote_refs (
+CREATE TABLE pggit.remote_refs (
     repo_id INTEGER,
     remote_name TEXT,
     ref_name TEXT NOT NULL,
     commit_hash TEXT NOT NULL,
     last_fetch TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, remote_name, ref_name),
-    FOREIGN KEY (repo_id, remote_name) REFERENCES pg_git.remotes(repo_id, name)
+    FOREIGN KEY (repo_id, remote_name) REFERENCES pggit.remotes(repo_id, name)
 );
 
 -- Add new functions for tags and remotes

--- a/sql/pgit-verify-commit.sql
+++ b/sql/pgit-verify-commit.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/025-verify-commit.sql
 -- Commit verification with GPG
 
-CREATE TABLE pg_git.gpg_keys (
+CREATE TABLE pggit.gpg_keys (
     repo_id INTEGER REFERENCES repositories(id),
     key_id TEXT NOT NULL,
     public_key TEXT NOT NULL,
@@ -11,25 +11,26 @@ CREATE TABLE pg_git.gpg_keys (
     PRIMARY KEY (repo_id, key_id)
 );
 
-CREATE TABLE pg_git.commit_signatures (
+CREATE TABLE pggit.commit_signatures (
     repo_id INTEGER REFERENCES repositories(id),
-    commit_hash TEXT NOT NULL REFERENCES commits(hash),
+    commit_hash TEXT NOT NULL,
     key_id TEXT NOT NULL,
     signature TEXT NOT NULL,
     signed_data TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (repo_id, commit_hash)
+    PRIMARY KEY (repo_id, commit_hash),
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.add_gpg_key(
+CREATE OR REPLACE FUNCTION pggit.add_gpg_key(
     p_repo_id INTEGER,
     p_key_id TEXT,
     p_public_key TEXT,
     p_user_id TEXT,
     p_trust_level TEXT DEFAULT 'unknown'
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.gpg_keys (repo_id, key_id, public_key, user_id, trust_level)
+    INSERT INTO pggit.gpg_keys (repo_id, key_id, public_key, user_id, trust_level)
     VALUES (p_repo_id, p_key_id, p_public_key, p_user_id, p_trust_level)
     ON CONFLICT (repo_id, key_id) DO UPDATE 
     SET public_key = p_public_key,
@@ -38,7 +39,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.verify_commit(
+CREATE OR REPLACE FUNCTION pggit.verify_commit(
     p_repo_id INTEGER,
     p_commit_hash TEXT,
     p_require_trust_level TEXT DEFAULT NULL
@@ -48,14 +49,14 @@ CREATE OR REPLACE FUNCTION pg_git.verify_commit(
     user_id TEXT,
     trust_level TEXT,
     verification_message TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_signature RECORD;
     v_key RECORD;
 BEGIN
     -- Get signature info
     SELECT * INTO v_signature
-    FROM pg_git.commit_signatures
+    FROM pggit.commit_signatures
     WHERE repo_id = p_repo_id
     AND commit_hash = p_commit_hash;
 
@@ -67,7 +68,7 @@ BEGIN
 
     -- Get key info
     SELECT * INTO v_key
-    FROM pg_git.gpg_keys
+    FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
     AND key_id = v_signature.key_id;
 
@@ -94,12 +95,12 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.sign_commit(
+CREATE OR REPLACE FUNCTION pggit.sign_commit(
     p_repo_id INTEGER,
     p_commit_hash TEXT,
     p_key_id TEXT,
     p_signature TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_signed_data TEXT;
 BEGIN
@@ -108,7 +109,7 @@ BEGIN
     FROM commits
     WHERE hash = p_commit_hash;
 
-    INSERT INTO pg_git.commit_signatures (
+    INSERT INTO pggit.commit_signatures (
         repo_id, commit_hash, key_id, signature, signed_data
     ) VALUES (
         p_repo_id, p_commit_hash, p_key_id, p_signature, v_signed_data

--- a/sql/pgit-verify-tag.sql
+++ b/sql/pgit-verify-tag.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/026-verify-tag.sql
 -- Tag verification with GPG
 
-CREATE TABLE pg_git.tag_signatures (
+CREATE TABLE pggit.tag_signatures (
     repo_id INTEGER REFERENCES repositories(id),
     tag_name TEXT NOT NULL,
     key_id TEXT NOT NULL,
@@ -9,24 +9,24 @@ CREATE TABLE pg_git.tag_signatures (
     signed_data TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, tag_name),
-    FOREIGN KEY (repo_id, key_id) REFERENCES pg_git.gpg_keys(repo_id, key_id)
+    FOREIGN KEY (repo_id, key_id) REFERENCES pggit.gpg_keys(repo_id, key_id)
 );
 
-CREATE OR REPLACE FUNCTION pg_git.sign_tag(
+CREATE OR REPLACE FUNCTION pggit.sign_tag(
     p_repo_id INTEGER,
     p_tag_name TEXT,
     p_key_id TEXT,
     p_signature TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
     v_signed_data TEXT;
 BEGIN
     -- Construct signed data from tag
     SELECT target_hash || tagger || message INTO v_signed_data
-    FROM pg_git.tags
+    FROM pggit.tags
     WHERE repo_id = p_repo_id AND name = p_tag_name;
 
-    INSERT INTO pg_git.tag_signatures (
+    INSERT INTO pggit.tag_signatures (
         repo_id, tag_name, key_id, signature, signed_data
     ) VALUES (
         p_repo_id, p_tag_name, p_key_id, p_signature, v_signed_data
@@ -34,7 +34,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.verify_tag(
+CREATE OR REPLACE FUNCTION pggit.verify_tag(
     p_repo_id INTEGER,
     p_tag_name TEXT,
     p_require_trust_level TEXT DEFAULT NULL
@@ -44,14 +44,14 @@ CREATE OR REPLACE FUNCTION pg_git.verify_tag(
     user_id TEXT,
     trust_level TEXT,
     verification_message TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_signature RECORD;
     v_key RECORD;
 BEGIN
     -- Get signature info
     SELECT * INTO v_signature
-    FROM pg_git.tag_signatures
+    FROM pggit.tag_signatures
     WHERE repo_id = p_repo_id
     AND tag_name = p_tag_name;
 
@@ -63,7 +63,7 @@ BEGIN
 
     -- Get key info
     SELECT * INTO v_key
-    FROM pg_git.gpg_keys
+    FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
     AND key_id = v_signature.key_id;
 
@@ -84,19 +84,19 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION pg_git.verify_all_tags(
+CREATE OR REPLACE FUNCTION pggit.verify_all_tags(
     p_repo_id INTEGER,
     p_require_trust_level TEXT DEFAULT NULL
 ) RETURNS TABLE (
     tag_name TEXT,
     is_valid BOOLEAN,
     verification_message TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
     SELECT t.name,
            v.is_valid,
            v.verification_message
-    FROM pg_git.tags t
-    LEFT JOIN LATERAL pg_git.verify_tag(p_repo_id, t.name, p_require_trust_level) v ON TRUE
+    FROM pggit.tags t
+    LEFT JOIN LATERAL pggit.verify_tag(p_repo_id, t.name, p_require_trust_level) v ON TRUE
     WHERE t.repo_id = p_repo_id
     ORDER BY t.name;
 $$ LANGUAGE sql;

--- a/sql/pgit-version-updates.sql
+++ b/sql/pgit-version-updates.sql
@@ -2,13 +2,13 @@
 -- pg_git update from version 0.1.0 to 0.2.0
 
 -- Create schema if not exists
-CREATE SCHEMA IF NOT EXISTS pg_git;
+CREATE SCHEMA IF NOT EXISTS pggit;
 
 -- Create extension update path
 ALTER EXTENSION pg_git UPDATE TO '0.2.0';
 
 -- Add tags support
-CREATE TABLE pg_git.tags (
+CREATE TABLE pggit.tags (
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     target_hash TEXT NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE pg_git.tags (
 );
 
 -- Add remote support
-CREATE TABLE pg_git.remotes (
+CREATE TABLE pggit.remotes (
     repo_id INTEGER REFERENCES repositories(id),
     name TEXT NOT NULL,
     url TEXT NOT NULL,
@@ -27,21 +27,21 @@ CREATE TABLE pg_git.remotes (
     PRIMARY KEY (repo_id, name)
 );
 
-CREATE TABLE pg_git.remote_refs (
+CREATE TABLE pggit.remote_refs (
     repo_id INTEGER,
     remote_name TEXT,
     ref_name TEXT NOT NULL,
     commit_hash TEXT NOT NULL,
     last_fetch TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (repo_id, remote_name, ref_name),
-    FOREIGN KEY (repo_id, remote_name) REFERENCES pg_git.remotes(repo_id, name)
+    FOREIGN KEY (repo_id, remote_name) REFERENCES pggit.remotes(repo_id, name)
 );
 
 -- Path: /sql/updates/pg_git--0.2.0.sql
 -- pg_git initial installation
 
 -- Create schema
-CREATE SCHEMA pg_git;
+CREATE SCHEMA pggit;
 
 -- Load core schema
 \ir ../schema/001-core.sql

--- a/sql/pgit-whatchanged.sql
+++ b/sql/pgit-whatchanged.sql
@@ -1,7 +1,7 @@
 -- Path: /sql/functions/027-whatchanged.sql
 -- Whatchanged command implementation
 
-CREATE OR REPLACE FUNCTION pg_git.whatchanged(
+CREATE OR REPLACE FUNCTION pggit.whatchanged(
     p_repo_id INTEGER,
     p_since TEXT DEFAULT NULL,
     p_until TEXT DEFAULT 'HEAD',
@@ -9,7 +9,7 @@ CREATE OR REPLACE FUNCTION pg_git.whatchanged(
 ) RETURNS TABLE (
     commit_hash TEXT,
     author TEXT,
-    timestamp TIMESTAMP WITH TIME ZONE,
+    "timestamp" TIMESTAMP WITH TIME ZONE,
     message TEXT,
     path TEXT,
     change_type TEXT,
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION pg_git.whatchanged(
     new_mode TEXT,
     old_hash TEXT,
     new_hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_since_hash TEXT;
     v_until_hash TEXT;
@@ -78,13 +78,13 @@ BEGIN
                    t2.mode as new_mode,
                    d.old_hash,
                    d.new_hash
-            FROM pg_git.diff_trees(
+            FROM pggit.diff_trees(
                 COALESCE(parent.repo_id, ch.repo_id),
                 parent.tree_hash,
                 ch.tree_hash
             ) d
-            LEFT JOIN pg_git.get_tree_entry(parent.tree_hash, d.path) t1 ON TRUE
-            LEFT JOIN pg_git.get_tree_entry(ch.tree_hash, d.path) t2 ON TRUE
+            LEFT JOIN pggit.get_tree_entry(parent.tree_hash, d.path) t1 ON TRUE
+            LEFT JOIN pggit.get_tree_entry(ch.tree_hash, d.path) t2 ON TRUE
             WHERE p_paths IS NULL OR d.path = ANY(p_paths)
         ) dt
     )
@@ -95,14 +95,14 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- Helper function to get a single tree entry
-CREATE OR REPLACE FUNCTION pg_git.get_tree_entry(
+CREATE OR REPLACE FUNCTION pggit.get_tree_entry(
     p_tree_hash TEXT,
     p_path TEXT
 ) RETURNS TABLE (
     mode TEXT,
     type TEXT,
     hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
     SELECT (e->>'mode')::TEXT,
            (e->>'type')::TEXT,
            (e->>'hash')::TEXT

--- a/sql/schema/001-core.sql
+++ b/sql/schema/001-core.sql
@@ -1,49 +1,59 @@
 -- Core tables
-CREATE TABLE pg_git.blobs (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.repositories (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    path TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE pggit.blobs (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     hash TEXT,
     content BYTEA NOT NULL,
     PRIMARY KEY (repo_id, hash)
 );
 
-CREATE TABLE pg_git.trees (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.trees (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     hash TEXT,
     entries JSONB NOT NULL,  -- [{mode, type, hash, name}]
     PRIMARY KEY (repo_id, hash)
 );
 
-CREATE TABLE pg_git.commits (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.commits (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     hash TEXT,
     tree_hash TEXT NOT NULL,
     parent_hash TEXT,
     author TEXT NOT NULL,
     message TEXT NOT NULL,
-    timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    -- clock_timestamp() (not CURRENT_TIMESTAMP) so commits created within a single
+    -- transaction receive distinct, monotonically increasing timestamps and can be
+    -- ordered relative to one another.
+    timestamp TIMESTAMP WITH TIME ZONE DEFAULT clock_timestamp(),
     PRIMARY KEY (repo_id, hash),
-    FOREIGN KEY (repo_id, tree_hash) REFERENCES pg_git.trees(repo_id, hash),
-    FOREIGN KEY (repo_id, parent_hash) REFERENCES pg_git.commits(repo_id, hash)
+    FOREIGN KEY (repo_id, tree_hash) REFERENCES pggit.trees(repo_id, hash),
+    FOREIGN KEY (repo_id, parent_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
-CREATE TABLE pg_git.refs (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+CREATE TABLE pggit.refs (
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     name TEXT,
     commit_hash TEXT NOT NULL,
     PRIMARY KEY (repo_id, name),
-    FOREIGN KEY (repo_id, commit_hash) REFERENCES pg_git.commits(repo_id, hash)
+    FOREIGN KEY (repo_id, commit_hash) REFERENCES pggit.commits(repo_id, hash)
 );
 
 -- Function to create a blob
 CREATE OR REPLACE FUNCTION create_blob(
     p_repo_id INTEGER,
     p_content BYTEA
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_hash TEXT;
 BEGIN
     v_hash := encode(sha256(p_content), 'hex');
-    INSERT INTO pg_git.blobs (repo_id, hash, content)
+    INSERT INTO pggit.blobs (repo_id, hash, content)
     VALUES (p_repo_id, v_hash, p_content)
     ON CONFLICT DO NOTHING;
     RETURN v_hash;
@@ -54,12 +64,12 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION create_tree(
     p_repo_id INTEGER,
     p_entries JSONB
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_hash TEXT;
 BEGIN
     v_hash := encode(sha256(p_entries::text::bytea), 'hex');
-    INSERT INTO pg_git.trees (repo_id, hash, entries)
+    INSERT INTO pggit.trees (repo_id, hash, entries)
     VALUES (p_repo_id, v_hash, p_entries)
     ON CONFLICT DO NOTHING;
     RETURN v_hash;
@@ -73,7 +83,7 @@ CREATE OR REPLACE FUNCTION create_commit(
     p_parent_hash TEXT,
     p_author TEXT,
     p_message TEXT
-) RETURNS TEXT AS $$
+) RETURNS TEXT SET search_path = pggit, public AS $$
 DECLARE
     v_hash TEXT;
     v_commit_data TEXT;
@@ -91,7 +101,7 @@ BEGIN
         RAISE EXCEPTION 'Commit hash calculation returned NULL';
     END IF;
 
-    INSERT INTO pg_git.commits (repo_id, hash, tree_hash, parent_hash, author, message)
+    INSERT INTO pggit.commits (repo_id, hash, tree_hash, parent_hash, author, message)
     VALUES (p_repo_id, v_hash, p_tree_hash, p_parent_hash, p_author, p_message);
     
     RETURN v_hash;
@@ -103,9 +113,9 @@ CREATE OR REPLACE FUNCTION update_ref(
     p_repo_id INTEGER,
     p_name TEXT,
     p_commit_hash TEXT
-) RETURNS VOID AS $$
+) RETURNS VOID SET search_path = pggit, public AS $$
 BEGIN
-    INSERT INTO pg_git.refs (repo_id, name, commit_hash)
+    INSERT INTO pggit.refs (repo_id, name, commit_hash)
     VALUES (p_repo_id, p_name, p_commit_hash)
     ON CONFLICT (repo_id, name) DO UPDATE
     SET commit_hash = p_commit_hash;
@@ -122,19 +132,19 @@ CREATE OR REPLACE FUNCTION get_commit_history(
     parent_hash TEXT,
     author TEXT,
     message TEXT,
-    timestamp TIMESTAMP WITH TIME ZONE
-) AS $$
+    "timestamp" TIMESTAMP WITH TIME ZONE
+) SET search_path = pggit, public AS $$
 WITH RECURSIVE commit_history AS (
-    SELECT * FROM pg_git.commits WHERE repo_id = p_repo_id AND hash = p_start_commit
+    SELECT * FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_start_commit
     UNION ALL
     SELECT c.*
-    FROM pg_git.commits c
+    FROM pggit.commits c
     INNER JOIN commit_history ch ON c.repo_id = p_repo_id AND c.hash = ch.parent_hash
 )
-SELECT * FROM commit_history;
+SELECT hash, tree_hash, parent_hash, author, message, "timestamp" FROM commit_history;
 $$ LANGUAGE sql;
 
--- Function to diff two pg_git.trees
+-- Function to diff two pggit.trees
 CREATE OR REPLACE FUNCTION diff_trees(
     p_repo_id INTEGER,
     p_old_tree_hash TEXT,
@@ -144,14 +154,14 @@ CREATE OR REPLACE FUNCTION diff_trees(
     path TEXT,
     old_hash TEXT,
     new_hash TEXT
-) AS $$
+) SET search_path = pggit, public AS $$
 DECLARE
     v_old_entries JSONB;
     v_new_entries JSONB;
 BEGIN
     -- Get tree entries
-    SELECT entries INTO v_old_entries FROM pg_git.trees WHERE repo_id = p_repo_id AND hash = p_old_tree_hash;
-    SELECT entries INTO v_new_entries FROM pg_git.trees WHERE repo_id = p_repo_id AND hash = p_new_tree_hash;
+    SELECT entries INTO v_old_entries FROM pggit.trees WHERE repo_id = p_repo_id AND hash = p_old_tree_hash;
+    SELECT entries INTO v_new_entries FROM pggit.trees WHERE repo_id = p_repo_id AND hash = p_new_tree_hash;
     
     -- Added files
     RETURN QUERY

--- a/sql/schema/pgit-schema.sql
+++ b/sql/schema/pgit-schema.sql
@@ -1,10 +1,10 @@
 -- Central schema definitions for PGit
 
 CREATE TABLE index_entries (
-    repo_id INTEGER REFERENCES pg_git.repositories(id),
+    repo_id INTEGER REFERENCES pggit.repositories(id),
     path TEXT NOT NULL,
     blob_hash TEXT NOT NULL,
     mode TEXT NOT NULL DEFAULT '100644',
     staged_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (repo_id, blob_hash) REFERENCES pg_git.blobs(repo_id, hash),
+    FOREIGN KEY (repo_id, blob_hash) REFERENCES pggit.blobs(repo_id, hash),
     PRIMARY KEY (repo_id, path));

--- a/test/sql/add_test.sql
+++ b/test/sql/add_test.sql
@@ -6,67 +6,68 @@ BEGIN;
 SELECT plan(10);
 
 -- Setup test repository
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
 
 -- Test staging a file
 SELECT lives_ok(
-    $$SELECT pg_git.stage_file(:repo_id, 'test.txt', 'test content'::bytea)$$,
+    $$SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'test content'::bytea)$$,
     'Can stage a file'
 );
 
 SELECT results_eq(
-    $$SELECT path FROM index_entries WHERE repo_id = :repo_id$$,
+    $$SELECT path FROM index_entries WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     $$VALUES ('test.txt')$$,
     'File path indexed correctly'
 );
 
 -- Test updating staged file
 SELECT lives_ok(
-    $$SELECT pg_git.stage_file(:repo_id, 'test.txt', 'updated content'::bytea)$$,
+    $$SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'updated content'::bytea)$$,
     'Can update staged file'
 );
 
 SELECT results_eq(
     $$SELECT encode(content, 'escape') FROM blobs b
     JOIN index_entries i ON b.hash = i.blob_hash
-    WHERE i.repo_id = :repo_id$$,
+    WHERE i.repo_id = (current_setting('vars.repo_id')::int)$$,
     $$VALUES ('updated content')$$,
     'Updated content stored correctly'
 );
 
 -- Test unstaging
 SELECT lives_ok(
-    $$SELECT pg_git.unstage_file(:repo_id, 'test.txt')$$,
+    $$SELECT pggit.unstage_file((current_setting('vars.repo_id')::int), 'test.txt')$$,
     'Can unstage file'
 );
 
 SELECT is_empty(
-    $$SELECT * FROM index_entries WHERE repo_id = :repo_id$$,
+    $$SELECT * FROM index_entries WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     'Index cleared after unstage'
 );
 
 -- Test path normalization
 SELECT lives_ok(
-    $$SELECT pg_git.stage_file(:repo_id, 'dir/./sub/../file.txt', 'norm content'::bytea)$$,
+    $$SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'dir/./sub/../file.txt', 'norm content'::bytea)$$,
     'Stages file with normalized path'
 );
 
 SELECT results_eq(
-    $$SELECT path FROM index_entries WHERE repo_id = :repo_id$$,
+    $$SELECT path FROM index_entries WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     $$VALUES ('dir/file.txt')$$,
     'Normalized path stored correctly'
 );
 
 -- Test rejection of path traversal
 SELECT throws_ok(
-    $$SELECT pg_git.stage_file(:repo_id, '../evil.txt', 'x'::bytea)$$,
+    $$SELECT pggit.stage_file((current_setting('vars.repo_id')::int), '../evil.txt', 'x'::bytea)$$,
     'Path traversal is not allowed',
     'Rejects path traversal'
 );
 
 -- Test rejection of absolute paths
 SELECT throws_ok(
-    $$SELECT pg_git.stage_file(:repo_id, '/etc/passwd', 'x'::bytea)$$,
+    $$SELECT pggit.stage_file((current_setting('vars.repo_id')::int), '/etc/passwd', 'x'::bytea)$$,
     'Absolute paths are not allowed',
     'Rejects absolute paths'
 );

--- a/test/sql/advanced_test.sql
+++ b/test/sql/advanced_test.sql
@@ -3,64 +3,65 @@
 
 BEGIN;
 
-SELECT plan(10);
+SELECT plan(9);
 
 -- Setup repository with an initial commit
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'content'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'author', 'init commit');
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'content'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'author', 'init commit');
 
 -- Stash save
 SELECT lives_ok(
-    $$SELECT pg_git.stash_save(:repo_id, 'WIP changes')$$,
+    $$SELECT pggit.stash_save((current_setting('vars.repo_id')::int), 'WIP changes')$$,
     'Can create stash'
 );
 
 SELECT results_eq(
-    $$SELECT COUNT(*) FROM pg_git.stash WHERE repo_id = :repo_id$$,
-    $$VALUES (1)$$,
+    $$SELECT COUNT(*) FROM pggit.stash WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    $$VALUES (1::bigint)$$,
     'Stash record created'
 );
 
 -- Stash pop
 SELECT lives_ok(
-    $$SELECT pg_git.stash_pop(:repo_id)$$,
+    $$SELECT pggit.stash_pop((current_setting('vars.repo_id')::int))$$,
     'Can apply stash'
 );
 
 SELECT is_empty(
-    $$SELECT * FROM pg_git.stash WHERE repo_id = :repo_id$$,
+    $$SELECT * FROM pggit.stash WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     'Stash cleared after pop'
 );
 
 -- Pack refs
 SELECT lives_ok(
-    $$SELECT pg_git.pack_refs(:repo_id, TRUE)$$,
+    $$SELECT pggit.pack_refs((current_setting('vars.repo_id')::int), TRUE)$$,
     'Can pack refs'
 );
 
 SELECT results_eq(
-    $$SELECT COUNT(*) FROM pg_git.packed_refs WHERE repo_id = :repo_id$$,
-    $$VALUES (1)$$,
+    $$SELECT COUNT(*) FROM pggit.packed_refs WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    $$VALUES (1::bigint)$$,
     'Packed refs created'
 );
 
 -- Repack objects
 SELECT lives_ok(
-    $$SELECT * FROM pg_git.repack(:repo_id)$$,
+    $$SELECT * FROM pggit.repack((current_setting('vars.repo_id')::int))$$,
     'Can repack objects'
 );
 
 -- Blame
 SELECT results_eq(
-    $$SELECT line_content FROM pg_git.blame(:repo_id, 'test.txt') LIMIT 1$$,
+    $$SELECT line_content FROM pggit.blame((current_setting('vars.repo_id')::int), 'test.txt') LIMIT 1$$,
     $$VALUES ('content')$$,
     'Blame returns line content'
 );
 
 -- Grep
 SELECT results_eq(
-    $$SELECT line_content FROM pg_git.grep(:repo_id, 'content') LIMIT 1$$,
+    $$SELECT line_content FROM pggit.grep((current_setting('vars.repo_id')::int), 'content') LIMIT 1$$,
     $$VALUES ('content')$$,
     'Grep finds pattern'
 );

--- a/test/sql/branch_test.sql
+++ b/test/sql/branch_test.sql
@@ -6,56 +6,57 @@ BEGIN;
 SELECT plan(8);
 
 -- Setup test repository with initial commit
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'test content'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'test_author', 'test commit');
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'test content'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'test_author', 'test commit');
 
 -- Test branch creation
 SELECT lives_ok(
-    $$SELECT pg_git.create_branch(:repo_id, 'test-branch')$$,
+    $$SELECT pggit.create_branch((current_setting('vars.repo_id')::int), 'test-branch')$$,
     'Can create branch'
 );
 
 SELECT results_eq(
-    $$SELECT name FROM pg_git.list_branches(:repo_id)$$,
+    $$SELECT name FROM pggit.list_branches((current_setting('vars.repo_id')::int))$$,
     $$VALUES ('master'), ('test-branch')$$,
     'Branch list shows all branches'
 );
 
 -- Test checkout
 SELECT lives_ok(
-    $$SELECT pg_git.checkout_branch(:repo_id, 'test-branch')$$,
+    $$SELECT pggit.checkout_branch((current_setting('vars.repo_id')::int), 'test-branch')$$,
     'Can checkout branch'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'test-branch'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'test-branch'$$,
     'HEAD points to correct commit after checkout'
 );
 
 -- Test new branch with start point
 SELECT lives_ok(
-    $$SELECT pg_git.create_branch(:repo_id, 'feature-branch', 
-        (SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'))$$,
+    $$SELECT pggit.create_branch((current_setting('vars.repo_id')::int), 'feature-branch', 
+        (SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'))$$,
     'Can create branch from specific commit'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'feature-branch'$$,
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'feature-branch'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'$$,
     'Branch created at correct commit'
 );
 
 -- Test checkout with create
 SELECT lives_ok(
-    $$SELECT pg_git.checkout_branch(:repo_id, 'new-branch', TRUE)$$,
+    $$SELECT pggit.checkout_branch((current_setting('vars.repo_id')::int), 'new-branch', TRUE)$$,
     'Can checkout with branch creation'
 );
 
 SELECT results_eq(
-    $$SELECT name FROM pg_git.list_branches(:repo_id)$$,
-    $$VALUES ('master'), ('test-branch'), ('feature-branch'), ('new-branch')$$,
+    $$SELECT name FROM pggit.list_branches((current_setting('vars.repo_id')::int))$$,
+    $$VALUES ('feature-branch'), ('master'), ('new-branch'), ('test-branch')$$,
     'New branch created and listed'
 );
 

--- a/test/sql/commit_test.sql
+++ b/test/sql/commit_test.sql
@@ -6,37 +6,38 @@ BEGIN;
 SELECT plan(9);
 
 -- Setup test repository and staged file
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'test content'::bytea);
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'test content'::bytea);
 
 -- Test commit creation
 SELECT lives_ok(
-    $$SELECT pg_git.commit_index(:repo_id, 'test_author', 'test commit')$$,
+    $$SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'test_author', 'test commit')$$,
     'Can create commit from index'
 );
 
 SELECT results_eq(
-    $$SELECT message FROM commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
+    $$SELECT message FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test commit')$$,
     'Commit message stored correctly'
 );
 
 SELECT results_eq(
-    $$SELECT author FROM commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
+    $$SELECT author FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test_author')$$,
     'Commit author stored correctly'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'$$,
     'Branch reference moves to new commit'
 );
 
 -- Test commit tree content
 SELECT results_eq(
     $$SELECT jsonb_array_length(entries) FROM trees t
-    JOIN commits c ON c.repo_id = :repo_id AND c.tree_hash = t.hash AND t.repo_id = :repo_id
+    JOIN commits c ON c.repo_id = (current_setting('vars.repo_id')::int) AND c.tree_hash = t.hash AND t.repo_id = (current_setting('vars.repo_id')::int)
     ORDER BY c.timestamp DESC LIMIT 1$$,
     $$VALUES (1)$$,
     'Commit tree has correct number of entries'
@@ -44,28 +45,28 @@ SELECT results_eq(
 
 -- Test index cleared after commit
 SELECT is_empty(
-    $$SELECT * FROM index_entries WHERE repo_id = :repo_id$$,
+    $$SELECT * FROM index_entries WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     'Index cleared after commit'
 );
 
 -- Test commit history
 SELECT results_eq(
-    $$SELECT COUNT(*) FROM pg_git.get_log(:repo_id)$$,
-    $$VALUES (2)$$,  -- Initial commit + our test commit
+    $$SELECT COUNT(*) FROM pggit.get_log((current_setting('vars.repo_id')::int))$$,
+    $$VALUES (2::bigint)$$,  -- Initial commit + our test commit
     'Commit history has correct length'
 );
 
 -- Test decorated log
 SELECT results_eq(
-    $$SELECT array_length(refs, 1) FROM pg_git.get_decorated_log(:repo_id) LIMIT 1$$,
+    $$SELECT array_length(refs, 1) FROM pggit.get_decorated_log((current_setting('vars.repo_id')::int)) LIMIT 1$$,
     $$VALUES (1)$$,
     'Decorated log shows correct number of refs'
 );
 
 -- Test parent relationship
 SELECT results_eq(
-    $$SELECT COUNT(*) FROM commits WHERE repo_id = :repo_id AND parent_hash IS NOT NULL$$,
-    $$VALUES (1)$$,
+    $$SELECT COUNT(*) FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) AND parent_hash IS NOT NULL$$,
+    $$VALUES (1::bigint)$$,
     'Parent relationship stored correctly'
 );
 

--- a/test/sql/diff_test.sql
+++ b/test/sql/diff_test.sql
@@ -7,20 +7,23 @@ SELECT plan(2);
 
 -- Direct diff_text check
 SELECT results_eq(
-    $$SELECT line_type || line_content FROM pg_git.diff_text('C\nA\nB', 'C\nB\nA')$$,
+    $$SELECT line_type || line_content FROM pggit.diff_text(E'C\nA\nB', E'C\nB\nA')$$,
     $$VALUES (' C'), ('-A'), ('+B'), ('-B'), ('+A')$$,
     'diff_text preserves line order'
 );
 
 -- Repository diff_commits check
-SELECT pg_git.init_repository('diff_repo', '/diff/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'C\nA\nB'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'author', 'initial') AS c1 \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'C\nB\nA'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'author', 'second') AS c2 \gset
+SELECT pggit.init_repository('diff_repo', '/diff/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', E'C\nA\nB'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'author', 'initial') AS c1 \gset
+SELECT set_config('vars.c1', :'c1', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', E'C\nB\nA'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'author', 'second') AS c2 \gset
+SELECT set_config('vars.c2', :'c2', false);
 
 SELECT results_eq(
-    $$SELECT unnest(diff_content) FROM pg_git.diff_commits(:c1, :c2) WHERE path = 'test.txt'$$,
+    $$SELECT unnest(diff_content) FROM pggit.diff_commits(current_setting('vars.c1'), current_setting('vars.c2')) WHERE path = 'test.txt'$$,
     $$VALUES (' C'), ('-A'), ('+B'), ('-B'), ('+A')$$,
     'diff_commits preserves line order'
 );

--- a/test/sql/gc_performance_test.sql
+++ b/test/sql/gc_performance_test.sql
@@ -6,9 +6,10 @@ BEGIN;
 SELECT plan(1);
 
 -- Setup test repository with a reachable commit
-SELECT pg_git.init_repository('perf_repo', '/perf/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'keep.txt', 'keep content'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'author', 'reachable commit');
+SELECT pggit.init_repository('perf_repo', '/perf/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'keep.txt', 'keep content'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'author', 'reachable commit');
 
 -- Create many unreachable objects
 DO $$
@@ -18,24 +19,24 @@ DECLARE
     tree_hash TEXT;
 BEGIN
     FOR i IN 1..1000 LOOP
-        blob_hash := pg_git.create_blob(:repo_id, ('orphan content ' || i)::bytea);
-        tree_hash := pg_git.create_tree(:repo_id,
+        blob_hash := pggit.create_blob((current_setting('vars.repo_id')::int), ('orphan content ' || i)::bytea);
+        tree_hash := pggit.create_tree((current_setting('vars.repo_id')::int),
             jsonb_build_array(
                 jsonb_build_object('mode','100644','type','blob','hash',blob_hash,'name','orphan' || i || '.txt')
             )
         );
-        PERFORM pg_git.create_commit(:repo_id, tree_hash, NULL, 'author', 'orphan commit');
+        PERFORM pggit.create_commit((current_setting('vars.repo_id')::int), tree_hash, NULL, 'author', 'orphan commit');
     END LOOP;
 END$$;
 
 -- Capture memory usage before GC
-SELECT sum(total_allocated) AS before_bytes FROM pg_backend_memory_contexts \gset
+SELECT sum(total_bytes) AS before_bytes FROM pg_backend_memory_contexts \gset
 
 -- Run garbage collection
-SELECT pg_git.gc(:repo_id);
+SELECT pggit.gc((current_setting('vars.repo_id')::int));
 
 -- Capture memory usage after GC
-SELECT sum(total_allocated) AS after_bytes FROM pg_backend_memory_contexts \gset
+SELECT sum(total_bytes) AS after_bytes FROM pg_backend_memory_contexts \gset
 
 -- Verify GC runs with limited memory growth (<5MB)
 SELECT ok( abs((:after_bytes::bigint - :before_bytes::bigint)) < 5000000,

--- a/test/sql/gc_test.sql
+++ b/test/sql/gc_test.sql
@@ -6,57 +6,63 @@ BEGIN;
 SELECT plan(7);
 
 -- Setup test repository and reachable commit
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'reachable.txt', 'reachable content'::bytea) AS reachable_blob \gset
-SELECT pg_git.commit_index(:repo_id, 'author', 'reachable commit') AS reachable_commit \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'reachable.txt', 'reachable content'::bytea) AS reachable_blob \gset
+SELECT set_config('vars.reachable_blob', :'reachable_blob', false);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'author', 'reachable commit') AS reachable_commit \gset
+SELECT set_config('vars.reachable_commit', :'reachable_commit', false);
 
 -- Create unreachable objects
-SELECT pg_git.create_blob(:repo_id, 'orphan content'::bytea) AS orphan_blob \gset
-SELECT pg_git.create_tree(:repo_id, jsonb_build_array(
+SELECT pggit.create_blob((current_setting('vars.repo_id')::int), 'orphan content'::bytea) AS orphan_blob \gset
+SELECT set_config('vars.orphan_blob', :'orphan_blob', false);
+SELECT pggit.create_tree((current_setting('vars.repo_id')::int), jsonb_build_array(
     jsonb_build_object('mode','100644','type','blob','hash', :'orphan_blob','name','orphan.txt')
 )) AS orphan_tree \gset
-SELECT pg_git.create_commit(:repo_id, :'orphan_tree', NULL, 'author', 'orphan commit') AS orphan_commit \gset
+SELECT set_config('vars.orphan_tree', :'orphan_tree', false);
+SELECT pggit.create_commit((current_setting('vars.repo_id')::int), :'orphan_tree', NULL, 'author', 'orphan commit') AS orphan_commit \gset
+SELECT set_config('vars.orphan_commit', :'orphan_commit', false);
 
 -- Run garbage collection
 SELECT results_eq(
-    $$SELECT object_type, objects_removed FROM pg_git.gc(:repo_id) ORDER BY object_type$$,
+    $$SELECT object_type, objects_removed FROM pggit.gc((current_setting('vars.repo_id')::int)) ORDER BY object_type$$,
     $$VALUES ('blobs',1), ('commits',1), ('trees',1)$$,
     'GC removed unreachable objects'
 );
 
 -- Verify reachable commit preserved and unreachable removed
 SELECT results_eq(
-    $$SELECT count(*) FROM commits WHERE repo_id = :repo_id$$,
-    $$VALUES (1)$$,
-    'Only reachable commit remains'
+    $$SELECT count(*) FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    $$VALUES (2::bigint)$$,  -- initial commit + reachable commit; orphan removed
+    'Only reachable commits remain'
 );
 
 SELECT results_eq(
-    $$SELECT hash FROM commits WHERE repo_id = :repo_id$$,
-    $$SELECT :'reachable_commit'$$,
+    $$SELECT hash FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) AND hash = current_setting('vars.reachable_commit')$$,
+    $$SELECT current_setting('vars.reachable_commit')$$,
     'Reachable commit preserved'
 );
 
 SELECT is_empty(
-    $$SELECT 1 FROM commits WHERE repo_id = :repo_id AND hash = :'orphan_commit'$$,
+    $$SELECT 1 FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) AND hash = current_setting('vars.orphan_commit')$$,
     'Unreachable commit removed'
 );
 
 -- Verify trees and blobs
 SELECT results_eq(
-    $$SELECT count(*) FROM trees WHERE repo_id = :repo_id$$,
-    $$VALUES (1)$$,
-    'Only reachable tree remains'
+    $$SELECT count(*) FROM trees WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    $$VALUES (2::bigint)$$,  -- initial empty tree + reachable tree; orphan removed
+    'Only reachable trees remain'
 );
 
 SELECT results_eq(
-    $$SELECT count(*) FROM blobs WHERE repo_id = :repo_id$$,
-    $$VALUES (1)$$,
+    $$SELECT count(*) FROM blobs WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    $$VALUES (1::bigint)$$,
     'Only reachable blob remains'
 );
 
 SELECT is_empty(
-    $$SELECT 1 FROM blobs WHERE repo_id = :repo_id AND hash = :'orphan_blob'$$,
+    $$SELECT 1 FROM blobs WHERE repo_id = (current_setting('vars.repo_id')::int) AND hash = current_setting('vars.orphan_blob')$$,
     'Unreachable blob removed'
 );
 

--- a/test/sql/https_fetch_test.sql
+++ b/test/sql/https_fetch_test.sql
@@ -1,30 +1,31 @@
 -- Path: /test/sql/https_fetch_test.sql
--- Tests for pg_git.http_fetch error handling
+-- Tests for pggit.http_fetch error handling
 
 BEGIN;
 
 SELECT plan(3);
 
 -- Setup test repository
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
 
 -- Successful fetch should return data
-SELECT like(
-    encode(pg_git.http_fetch(:repo_id, 'https://httpbin.org/get'), 'escape'),
+SELECT alike(
+    encode(pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://httpbin.org/get'), 'escape'),
     '%"url": "https://httpbin.org/get"%',
     'Successful fetch returns expected content'
 );
 
 -- Timeout scenario
 SELECT throws_like(
-    $$SELECT pg_git.http_fetch(:repo_id, 'https://httpbin.org/delay/20')$$,
+    $$SELECT pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://httpbin.org/delay/20')$$,
     'timed out',
     'Timeout raises error'
 );
 
 -- Certificate verification error scenario
 SELECT throws_like(
-    $$SELECT pg_git.http_fetch(:repo_id, 'https://self-signed.badssl.com/')$$,
+    $$SELECT pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://self-signed.badssl.com/')$$,
     'certificate verify failed',
     'Certificate error raises exception'
 );

--- a/test/sql/init.sql
+++ b/test/sql/init.sql
@@ -2,16 +2,18 @@
 -- pg_git initialization tests
 
 CREATE EXTENSION IF NOT EXISTS pgtap;
-CREATE EXTENSION IF NOT EXISTS pg_git;
+-- CASCADE auto-installs the required extensions (pgcrypto, pg_trgm, plpython3u).
+CREATE EXTENSION IF NOT EXISTS pg_git CASCADE;
 
 BEGIN;
 
 SELECT plan(12);
 
 -- Test repository creation
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
 SELECT lives_ok(
-    $$SELECT :repo_id$$,
+    $$SELECT (current_setting('vars.repo_id')::int)$$,
     'Can create repository'
 );
 
@@ -22,40 +24,40 @@ SELECT results_eq(
 );
 
 SELECT results_eq(
-    $$SELECT name FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
+    $$SELECT name FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'$$,
     $$VALUES ('HEAD')$$,
     'HEAD reference created'
 );
 
 -- Test blob creation
 SELECT lives_ok(
-    $$SELECT pg_git.create_blob(:repo_id, 'test content'::bytea)$$,
+    $$SELECT pggit.create_blob((current_setting('vars.repo_id')::int), 'test content'::bytea)$$,
     'Can create blob'
 );
 
 SELECT results_eq(
-    $$SELECT encode(content, 'escape') FROM blobs WHERE repo_id = :repo_id LIMIT 1$$,
+    $$SELECT encode(content, 'escape') FROM blobs WHERE repo_id = (current_setting('vars.repo_id')::int) LIMIT 1$$,
     $$VALUES ('test content')$$,
     'Blob content stored correctly'
 );
 
 -- Test tree creation
 SELECT lives_ok(
-    $$SELECT pg_git.create_tree(:repo_id, '[{"mode": "100644", "type": "blob", "hash": "abc", "name": "test.txt"}]'::jsonb)$$,
+    $$SELECT pggit.create_tree((current_setting('vars.repo_id')::int), '[{"mode": "100644", "type": "blob", "hash": "abc", "name": "test.txt"}]'::jsonb)$$,
     'Can create tree'
 );
 
 SELECT results_eq(
-    $$SELECT entries->0->>'name' FROM trees WHERE repo_id = :repo_id LIMIT 1$$,
+    $$SELECT entries->0->>'name' FROM trees WHERE repo_id = (current_setting('vars.repo_id')::int) AND jsonb_array_length(entries) > 0 LIMIT 1$$,
     $$VALUES ('test.txt')$$,
     'Tree entries stored correctly'
 );
 
 -- Test basic commit
 SELECT lives_ok(
-    $$SELECT pg_git.create_commit(
-        :repo_id,
-        (SELECT hash FROM trees WHERE repo_id = :repo_id LIMIT 1),
+    $$SELECT pggit.create_commit(
+        (current_setting('vars.repo_id')::int),
+        (SELECT hash FROM trees WHERE repo_id = (current_setting('vars.repo_id')::int) LIMIT 1),
         NULL,
         'test_author',
         'test commit'
@@ -64,25 +66,25 @@ SELECT lives_ok(
 );
 
 SELECT results_eq(
-    $$SELECT message FROM commits WHERE repo_id = :repo_id LIMIT 1$$,
+    $$SELECT message FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test commit')$$,
     'Commit message stored correctly'
 );
 
 SELECT results_eq(
-    $$SELECT author FROM commits WHERE repo_id = :repo_id LIMIT 1$$,
+    $$SELECT author FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('test_author')$$,
     'Commit author stored correctly'
 );
 
 -- Test refs
 SELECT lives_ok(
-    $$SELECT pg_git.update_ref(:repo_id, 'test_branch', (SELECT hash FROM commits WHERE repo_id = :repo_id LIMIT 1))$$,
+    $$SELECT pggit.update_ref((current_setting('vars.repo_id')::int), 'test_branch', (SELECT hash FROM commits WHERE repo_id = (current_setting('vars.repo_id')::int) LIMIT 1))$$,
     'Can create branch reference'
 );
 
 SELECT results_eq(
-    $$SELECT name FROM refs WHERE repo_id = :repo_id AND name = 'test_branch'$$,
+    $$SELECT name FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'test_branch'$$,
     $$VALUES ('test_branch')$$,
     'Branch reference created correctly'
 );

--- a/test/sql/merge_test.sql
+++ b/test/sql/merge_test.sql
@@ -6,52 +6,55 @@ BEGIN;
 SELECT plan(6);
 
 -- Setup test repository with branched history
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'test.txt', 'test content'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'test_author', 'main commit') AS main_commit \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'test.txt', 'test content'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'test_author', 'main commit') AS main_commit \gset
+SELECT set_config('vars.main_commit', :'main_commit', false);
 
-SELECT pg_git.create_branch(:repo_id, 'feature');
-SELECT pg_git.checkout_branch(:repo_id, 'feature');
-SELECT pg_git.stage_file(:repo_id, 'feature.txt', 'feature content'::bytea);
-SELECT pg_git.commit_index(:repo_id, 'test_author', 'feature commit') AS feature_commit \gset
+SELECT pggit.create_branch((current_setting('vars.repo_id')::int), 'feature');
+SELECT pggit.checkout_branch((current_setting('vars.repo_id')::int), 'feature');
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'feature.txt', 'feature content'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'test_author', 'feature commit') AS feature_commit \gset
+SELECT set_config('vars.feature_commit', :'feature_commit', false);
 
 -- Test merge base finding
 SELECT results_eq(
-    $$SELECT pg_git.find_merge_base(:main_commit, :feature_commit)$$,
-    $$SELECT :main_commit$$,
+    $$SELECT pggit.find_merge_base(current_setting('vars.main_commit'), current_setting('vars.feature_commit'))$$,
+    $$SELECT current_setting('vars.main_commit')$$,
     'Finds correct merge base'
 );
 
 -- Test fast-forward possible check
 SELECT results_eq(
-    $$SELECT pg_git.can_fast_forward(:main_commit, :feature_commit)$$,
+    $$SELECT pggit.can_fast_forward(current_setting('vars.main_commit'), current_setting('vars.feature_commit'))$$,
     $$VALUES (true)$$,
     'Correctly identifies fast-forward possibility'
 );
 
 -- Test basic merge
 SELECT lives_ok(
-    $$SELECT pg_git.merge_branches(:repo_id, 'feature', 'master')$$,
+    $$SELECT pggit.merge_branches((current_setting('vars.repo_id')::int), 'feature', 'master')$$,
     'Can perform merge'
 );
 
 -- Test HEAD after merge
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
-    $$SELECT :feature_commit$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'$$,
+    $$SELECT current_setting('vars.feature_commit')$$,
     'HEAD points to correct commit after merge'
 );
 
 -- Test branch pointer after merge
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'master'$$,
-    $$SELECT :feature_commit$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'$$,
+    $$SELECT current_setting('vars.feature_commit')$$,
     'Branch points to correct commit after merge'
 );
 
 -- Test merge conflict detection
 SELECT throws_ok(
-    $$SELECT pg_git.merge_branches(:repo_id, 'invalid-branch')$$,
+    $$SELECT pggit.merge_branches((current_setting('vars.repo_id')::int), 'invalid-branch')$$,
     'Branch invalid-branch does not exist',
     'Detects invalid branch names'
 );

--- a/test/sql/optimize_indexes_test.sql
+++ b/test/sql/optimize_indexes_test.sql
@@ -6,47 +6,46 @@ BEGIN;
 SELECT plan(3);
 
 -- Initialize repository
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset;
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
 
 -- Determine expected number of indexes
 SELECT count(*) AS total_indexes
 FROM pg_indexes i
-JOIN pg_tables t ON i.tablename = t.tablename
-WHERE t.schemaname = 'pg_git'
+JOIN pg_tables t ON i.schemaname = t.schemaname AND i.tablename = t.tablename
+WHERE t.schemaname = 'pggit'
 \gset
+SELECT set_config('vars.total_indexes', :'total_indexes', false);
 
 -- Successful reindex run
 SELECT results_eq(
-    $$SELECT count(*) FROM pg_git.optimize_indexes(:repo_id)$$,
-    $$SELECT :total_indexes$$,
+    $$SELECT count(*)::int FROM pggit.optimize_indexes((current_setting('vars.repo_id')::int))$$,
+    $$SELECT (current_setting('vars.total_indexes')::int)$$,
     'Returned one row per index'
 );
 
 SELECT is_empty(
-    $$SELECT * FROM pg_git.optimize_indexes(:repo_id) WHERE NOT success$$,
+    $$SELECT * FROM pggit.optimize_indexes((current_setting('vars.repo_id')::int)) WHERE NOT success$$,
     'All indexes reindexed successfully'
 );
 
--- Setup failure to simulate errors
-CREATE OR REPLACE FUNCTION fail_all_reindex() RETURNS event_trigger AS $$
-BEGIN
-    RAISE EXCEPTION 'simulated failure';
-END;
-$$ LANGUAGE plpgsql;
+-- Simulate reindex errors: an unprivileged role owns none of the pggit indexes,
+-- so every REINDEX it attempts is rejected and captured with success = FALSE.
+-- The function runs as that role; the captured rows are asserted as the test
+-- role so pgTAP's own bookkeeping is unaffected.
+CREATE ROLE pggit_test_unpriv;
+GRANT USAGE ON SCHEMA pggit TO pggit_test_unpriv;
 
-CREATE EVENT TRIGGER fail_reindex
-    ON ddl_command_start
-    WHEN TAG IN ('REINDEX INDEX')
-    EXECUTE PROCEDURE fail_all_reindex();
+SET LOCAL ROLE pggit_test_unpriv;
+CREATE TEMP TABLE optimize_results AS
+    SELECT * FROM pggit.optimize_indexes((current_setting('vars.repo_id')::int));
+RESET ROLE;
 
 -- Failure scenario run
 SELECT is_empty(
-    $$SELECT * FROM pg_git.optimize_indexes(:repo_id) WHERE success$$,
+    $$SELECT * FROM optimize_results WHERE success$$,
     'Reindex failures captured'
 );
-
-DROP EVENT TRIGGER fail_reindex;
-DROP FUNCTION fail_all_reindex();
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/test/sql/remote_test.sql
+++ b/test/sql/remote_test.sql
@@ -6,63 +6,64 @@ BEGIN;
 SELECT plan(10);
 
 -- Setup test repository
-SELECT pg_git.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
 
 -- Test remote addition
 SELECT lives_ok(
-    $$SELECT pg_git.add_remote(:repo_id, 'origin', 'postgresql://remote/repo')$$,
+    $$SELECT pggit.add_remote((current_setting('vars.repo_id')::int), 'origin', 'postgresql://remote/repo')$$,
     'Can add remote'
 );
 
 SELECT results_eq(
-    $$SELECT url FROM pg_git.remotes WHERE repo_id = :repo_id$$,
+    $$SELECT url FROM pggit.remotes WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     $$VALUES ('postgresql://remote/repo')$$,
     'Remote URL stored correctly'
 );
 
 -- Prepare a remote branch tip that fetch materializes into refs as origin/master
 SELECT lives_ok(
-    $$INSERT INTO pg_git.remote_refs (repo_id, remote_name, ref_name, commit_hash)
-      SELECT :repo_id, 'origin', 'master', commit_hash
+    $$INSERT INTO pggit.remote_refs (repo_id, remote_name, ref_name, commit_hash)
+      SELECT (current_setting('vars.repo_id')::int), 'origin', 'master', commit_hash
       FROM refs
-      WHERE repo_id = :repo_id AND name = 'master'$$,
+      WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'$$,
     'Can track remote refs'
 );
 
 -- Test fetch operation
 SELECT lives_ok(
-    $$SELECT * FROM pg_git.fetch_remote(:repo_id, 'origin')$$,
+    $$SELECT * FROM pggit.fetch_remote((current_setting('vars.repo_id')::int), 'origin')$$,
     'Can fetch from remote'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM refs WHERE repo_id = :repo_id AND name = 'origin/master'$$,
-    $$SELECT commit_hash FROM pg_git.remote_refs WHERE repo_id = :repo_id AND remote_name = 'origin' AND ref_name = 'master'$$,
+    $$SELECT commit_hash FROM refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'origin/master'$$,
+    $$SELECT commit_hash FROM pggit.remote_refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND remote_name = 'origin' AND ref_name = 'master'$$,
     'Fetch materializes remote tracking ref in refs'
 );
 
 -- Test push operation
 SELECT lives_ok(
-    $$SELECT pg_git.push(:repo_id, 'origin', 'master')$$,
+    $$SELECT pggit.push((current_setting('vars.repo_id')::int), 'origin', 'master')$$,
     'Can push to remote'
 );
 
 -- Test pull operation succeeds when tracking branch exists
 SELECT lives_ok(
-    $$SELECT pg_git.pull(:repo_id, 'origin', 'master')$$,
+    $$SELECT pggit.pull((current_setting('vars.repo_id')::int), 'origin', 'master')$$,
     'Can pull from remote tracked branch'
 );
 
 -- Test pull operation fails with clear error when branch is missing remotely
-SELECT throws_ok(
-    $$SELECT pg_git.pull(:repo_id, 'origin', 'feature')$$,
+SELECT throws_matching(
+    $$SELECT pggit.pull((current_setting('vars.repo_id')::int), 'origin', 'feature')$$,
     'Remote-tracking ref origin/feature does not exist for repo .*',
     'Pull fails when remote tracking branch is missing'
 );
 
 -- Test clone operation
 SELECT lives_ok(
-    $$SELECT pg_git.clone('postgresql://remote/repo', 'clone_test', '/clone/path')$$,
+    $$SELECT pggit.clone('postgresql://remote/repo', 'clone_test', '/clone/path')$$,
     'Can clone repository'
 );
 

--- a/test/sql/search_path_qualification_test.sql
+++ b/test/sql/search_path_qualification_test.sql
@@ -7,28 +7,29 @@ SELECT plan(4);
 
 SET LOCAL search_path TO public;
 
-SELECT pg_git.init_repository('spath_repo', '/tmp/spath_repo') AS repo_id \gset
-SELECT pg_git.stage_file(:repo_id, 'file.txt', 'hello world'::bytea);
+SELECT pggit.init_repository('spath_repo', '/tmp/spath_repo') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'file.txt', 'hello world'::bytea);
 
 SELECT lives_ok(
-    $$SELECT pg_git.commit_index(:repo_id, 'search_path_tester', 'commit under custom search_path')$$,
+    $$SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'search_path_tester', 'commit under custom search_path')$$,
     'Commit succeeds with non-default search_path'
 );
 
 SELECT results_eq(
-    $$SELECT COUNT(*)::bigint FROM pg_git.commits WHERE repo_id = :repo_id$$,
+    $$SELECT COUNT(*)::bigint FROM pggit.commits WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
     $$VALUES (2::bigint)$$,
-    'Commit rows are written in pg_git.commits'
+    'Commit rows are written in pggit.commits'
 );
 
 SELECT results_eq(
-    $$SELECT commit_hash FROM pg_git.refs WHERE repo_id = :repo_id AND name = 'master'$$,
-    $$SELECT commit_hash FROM pg_git.refs WHERE repo_id = :repo_id AND name = 'HEAD'$$,
+    $$SELECT commit_hash FROM pggit.refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'master'$$,
+    $$SELECT commit_hash FROM pggit.refs WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'$$,
     'HEAD and master remain aligned after commit'
 );
 
 SELECT results_eq(
-    $$SELECT message FROM pg_git.commits WHERE repo_id = :repo_id ORDER BY timestamp DESC LIMIT 1$$,
+    $$SELECT message FROM pggit.commits WHERE repo_id = (current_setting('vars.repo_id')::int) ORDER BY timestamp DESC LIMIT 1$$,
     $$VALUES ('commit under custom search_path'::text)$$,
     'Latest commit message is stored correctly'
 );


### PR DESCRIPTION
## Summary

CI has been **red on every run** because the extension could never be created and no tests could run. This PR makes `CREATE EXTENSION pg_git` work and brings the full suite to green:

- **Core suite: 80/80 passing** (what `make test` and the main CI job run)
- **Performance suite: passing** (`RUN_PERF=1`)
- **Integration suite (`RUN_INTEGRATION=1`):** SQL/function bugs fixed; it still requires real outbound HTTPS (httpbin.org / badssl.com), as the README documents.

## Root-cause blockers (the extension never installed)

1. **Illegal schema name.** Everything lived in a `pg_git` schema, but PostgreSQL reserves the `pg_` prefix for system schemas, so `CREATE SCHEMA pg_git` is rejected. Renamed the object schema to **`pggit`** (the extension itself is still named `pg_git`).
2. **Bad control file.** `relocatable = true` cannot be combined with `schema = …`. Now `relocatable = false`, `schema = pggit`.
3. **`\i`/`\ir` in the load script.** `CREATE EXTENSION` cannot process psql include directives. The single install script `sql/pg_git--0.4.0.sql` is now **assembled from the modular fragments at build time** (`make`), excluding CI/control fragments and version-upgrade scripts.
4. **Load ordering / search_path.** The core `repositories` table now precedes the tables that reference it, and **every function carries a fixed `SET search_path = pggit, public`** so calls work under any caller search_path (this is exactly what `search_path_qualification_test` checks).

## Notable function fixes

- Quote reserved-word identifiers (`timestamp`, `references`, `offset`).
- Composite FKs to the `(repo_id, hash)`-keyed object tables.
- `find_merge_base` / `can_fast_forward` → 2-arg API, valid recursive CTEs; `merge_branches` validates branches and fast-forwards in the correct direction.
- `gc` rewritten to a single-self-reference recursive CTE; object labels unprefixed.
- `get_log` / `get_commit_history` project their declared columns; `diff_text` returns rows (and uses `TEXT`); `get_decorated_log` excludes `HEAD`.
- `optimize_indexes` emits via `RETURN NEXT` (no temp table); `blame`/`grep` column fixes; `repack` hashes over `bytea`; truncated `merge_trees` completed; `replace`/`submodule` statements fixed; `http_fetch` uses a prepared plan.
- `commits.timestamp` defaults to `clock_timestamp()` so commits within one transaction order correctly.
- Path-validation errors are clean (`Path traversal is not allowed`), with the offending path in `DETAIL`.

## Test / CI fixes

- `\gset`-captured values are passed to SQL through session GUCs, because psql does not interpolate `:vars` inside dollar-quoted strings.
- The test runner sets `search_path`; `init.sql` uses `CREATE EXTENSION pg_git CASCADE` so required extensions auto-install on a clean database.
- Assorted assertion/type fixes (`bigint` counts, branch ordering, `alike` vs `like`, `throws_matching`, reindex-failure injection via an unprivileged role).

README updated for the `pggit` schema and `CASCADE` install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALV1QWvB9PxgRWmoiTYLQk)_