### PR TITLE
Make https_fetch integration test self-contained (fix scheduled CI)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     postgresql-server-dev-14 \
     git \
+    openssl \
     postgresql-14-pgtap \
     postgresql-plpython3-14 \
     libtap-parser-sourcehandler-pgtap-perl \

--- a/test/sql/https_fetch_test.sql
+++ b/test/sql/https_fetch_test.sql
@@ -1,5 +1,10 @@
 -- Path: /test/sql/https_fetch_test.sql
--- Tests for pggit.http_fetch error handling
+-- Tests for pggit.http_fetch.
+--
+-- These exercise the success path, the read-timeout path and TLS certificate
+-- verification. To keep the suite deterministic in CI they run against local
+-- servers started inside the backend rather than third-party endpoints, so the
+-- result never depends on the availability of an external service.
 
 BEGIN;
 
@@ -9,27 +14,116 @@ SELECT plan(3);
 SELECT pggit.init_repository('test_repo', '/test/path') AS repo_id \gset
 SELECT set_config('vars.repo_id', :'repo_id', false);
 
--- Successful fetch should return data
+-- Start local HTTP and HTTPS test servers in daemon threads within this
+-- backend. http_fetch runs in the same backend, so it can reach them over the
+-- loopback interface. OS-assigned ports are stashed in GUCs for the assertions.
+DO $py$
+import http.server
+import os
+import socket
+import ssl
+import subprocess
+import tempfile
+import threading
+import time
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        # A slow endpoint lets us trip http_fetch's built-in 10s read timeout.
+        if self.path.startswith('/slow'):
+            time.sleep(12)
+        body = b'pg_git local server OK'
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/plain')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # keep the test output quiet
+        pass
+
+
+httpd = http.server.ThreadingHTTPServer(('127.0.0.1', 0), _Handler)
+http_port = httpd.server_address[1]
+threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+# A self-signed certificate for the verification-failure case. Generated at
+# runtime (via the openssl CLI) so no private key is committed to the repo.
+certdir = tempfile.mkdtemp(prefix='pggit_tls_')
+certfile = os.path.join(certdir, 'cert.pem')
+keyfile = os.path.join(certdir, 'key.pem')
+subprocess.run(
+    ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+     '-keyout', keyfile, '-out', certfile,
+     '-days', '3650', '-subj', '/CN=pggit-test'],
+    check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+tls_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+tls_ctx.load_cert_chain(certfile, keyfile)
+
+tls_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+tls_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+tls_sock.bind(('127.0.0.1', 0))
+tls_sock.listen(5)
+tls_port = tls_sock.getsockname()[1]
+
+
+def _serve_tls():
+    while True:
+        try:
+            conn, _ = tls_sock.accept()
+        except OSError:
+            return
+        try:
+            # The client rejects the self-signed cert during the handshake;
+            # we just need to present it.
+            tls_ctx.wrap_socket(conn, server_side=True)
+        except (ssl.SSLError, OSError):
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
+threading.Thread(target=_serve_tls, daemon=True).start()
+
+plpy.execute("SELECT set_config('vars.http_port', '%d', false)" % http_port)
+plpy.execute("SELECT set_config('vars.tls_port', '%d', false)" % tls_port)
+$py$ LANGUAGE plpython3u;
+
+-- Successful fetch should return the served body.
 SELECT alike(
-    encode(pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://httpbin.org/get'), 'escape'),
-    '%"url": "https://httpbin.org/get"%',
+    encode(
+        pggit.http_fetch(
+            current_setting('vars.repo_id')::int,
+            'http://127.0.0.1:' || current_setting('vars.http_port') || '/'),
+        'escape'),
+    '%local server OK%',
     'Successful fetch returns expected content'
 );
 
--- Timeout scenario
+-- Timeout scenario: the slow endpoint exceeds http_fetch's read timeout.
 SELECT throws_like(
-    $$SELECT pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://httpbin.org/delay/20')$$,
-    'timed out',
+    format(
+        $$SELECT pggit.http_fetch(%s, %L)$$,
+        current_setting('vars.repo_id'),
+        'http://127.0.0.1:' || current_setting('vars.http_port') || '/slow'),
+    '%timed out%',
     'Timeout raises error'
 );
 
--- Certificate verification error scenario
+-- Certificate verification error scenario: the server presents a self-signed cert.
 SELECT throws_like(
-    $$SELECT pggit.http_fetch((current_setting('vars.repo_id')::int), 'https://self-signed.badssl.com/')$$,
-    'certificate verify failed',
+    format(
+        $$SELECT pggit.http_fetch(%s, %L)$$,
+        current_setting('vars.repo_id'),
+        'https://127.0.0.1:' || current_setting('vars.tls_port') || '/'),
+    '%certificate verify failed%',
     'Certificate error raises exception'
 );
 
 SELECT * FROM finish();
 ROLLBACK;
-


### PR DESCRIPTION
## What was failing

The build itself (`make` / `make install`) and the core test suite are fine. The red CI was the **scheduled `test-slow-suites` job**, which runs the integration suite.

`test/sql/https_fetch_test.sql` made live requests to third-party endpoints (`httpbin.org`, `self-signed.badssl.com`). In the most recent scheduled run, `httpbin.org` was slow, so the very first assertion raised a raw `TimeoutError` that aborted the whole pgTAP plan:

```
psql:test/sql/https_fetch_test.sql:17: ERROR:  TimeoutError: The read operation timed out
...
Parse errors: Bad plan.  You planned 3 tests but ran 0.
make: *** [makefile:121: test-integration] Error 1
```

So the run went red on **external-service flakiness**, not on a real defect in `pg_git`.

## The fix

Rewrite the test to run against **local servers started inside the backend** via `plpython3u`, covering the same three cases deterministically and with no network access:

- **success** – a loopback HTTP server returns a known body
- **timeout** – a slow endpoint trips `http_fetch`'s built-in 10s read timeout
- **cert error** – a loopback HTTPS listener presents a self-signed certificate, so verification fails with `certificate verify failed`

The self-signed certificate is generated at runtime with `openssl`, so **no private key is committed** to the repo. `openssl` is added to the Docker image to guarantee the CLI is present.

`pggit.http_fetch` is unchanged — only the test and the Dockerfile.

## Verification

Ran end-to-end against PostgreSQL with `plpython3u`, `pgcrypto`, `pg_trgm`, and pgTAP, fully offline:

```
test/sql/https_fetch_test.sql ................ ok
All tests successful.
Files=12, Tests=83
```

All three assertions pass, and the full suite (core + integration) is green without any outbound network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EE6Yw6J4y7XrWhjKSsKEXN)_