### PR TITLE
Get pg_git to spec: fix broken merge-conflict/reset paths and expand test coverage

### DIFF
--- a/makefile
+++ b/makefile
@@ -59,8 +59,10 @@ CORE_TESTS := \
        test/sql/commit_test.sql \
        test/sql/diff_test.sql \
        test/sql/merge_test.sql \
+       test/sql/merge_conflicts_test.sql \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
+       test/sql/reset_test.sql \
        test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \
        test/sql/optimize_indexes_test.sql

--- a/sql/functions/009-reset.sql
+++ b/sql/functions/009-reset.sql
@@ -30,12 +30,21 @@ CREATE OR REPLACE FUNCTION pggit.reset_file(
     p_commit TEXT DEFAULT 'HEAD'
 ) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
+    v_commit_hash TEXT;
     v_tree_hash TEXT;
     v_blob_hash TEXT;
 BEGIN
+    -- Resolve p_commit: a ref name (e.g. the default 'HEAD' or a branch) maps to
+    -- its commit hash; otherwise it is already a commit hash. Without this the
+    -- default 'HEAD' is looked up as a literal commit hash, finds nothing, and
+    -- the file is wrongly dropped from the index instead of restored.
+    SELECT commit_hash INTO v_commit_hash
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_commit;
+    v_commit_hash := COALESCE(v_commit_hash, p_commit);
+
     -- Get tree from commit
     SELECT tree_hash INTO v_tree_hash
-    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_commit;
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = v_commit_hash;
     
     -- Get blob hash from tree
     SELECT (e->>'hash')::TEXT INTO v_blob_hash

--- a/sql/functions/013-merge-conflicts.sql
+++ b/sql/functions/013-merge-conflicts.sql
@@ -17,6 +17,21 @@ CREATE TABLE pggit.merge_conflicts (
     FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
 );
 
+-- A three-way merge of a single path needs no manual resolution when either
+-- side is unchanged from the base (take the other side) or both sides resolve
+-- to the same blob. Anything else is a genuine conflict. NULL means the file is
+-- absent on that side (added or deleted), so IS [NOT] DISTINCT FROM is used to
+-- compare hashes without tripping over NULL semantics.
+CREATE OR REPLACE FUNCTION pggit.can_auto_merge(
+    p_our_hash TEXT,
+    p_their_hash TEXT,
+    p_base_hash TEXT
+) RETURNS BOOLEAN IMMUTABLE SET search_path = pggit, public AS $$
+    SELECT p_our_hash IS NOT DISTINCT FROM p_their_hash   -- both sides agree
+        OR p_our_hash IS NOT DISTINCT FROM p_base_hash    -- we didn't change it
+        OR p_their_hash IS NOT DISTINCT FROM p_base_hash; -- they didn't change it
+$$ LANGUAGE sql;
+
 CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
     p_repo_id INTEGER,
     p_our_commit TEXT,
@@ -27,36 +42,48 @@ CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
 ) SET search_path = pggit, public AS $$
 DECLARE
     v_base_commit TEXT;
+    v_our_tree TEXT;
+    v_their_tree TEXT;
+    v_base_tree TEXT;
 BEGIN
-    -- Find merge base
-    v_base_commit := pggit.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
-    
+    -- Find merge base (find_merge_base identifies the repo from the commits).
+    v_base_commit := pggit.find_merge_base(p_our_commit, p_their_commit);
+
+    -- Resolve each commit to its tree. get_tree_files expects a tree hash, not
+    -- a commit hash. A missing/NULL commit yields a NULL tree, i.e. no files.
+    SELECT tree_hash INTO v_our_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_our_commit;
+    SELECT tree_hash INTO v_their_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_their_commit;
+    SELECT tree_hash INTO v_base_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = v_base_commit;
+
     RETURN QUERY
+    -- Columns are qualified via the function alias: the RETURNS TABLE OUT
+    -- parameter "path" would otherwise shadow the unqualified column name.
     WITH our_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(p_our_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_our_tree) gtf
     ),
     their_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(p_their_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_their_tree) gtf
     ),
     base_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(v_base_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_base_tree) gtf
     )
     SELECT DISTINCT f.path,
            CASE
-               WHEN o.blob_hash != t.blob_hash 
-                    AND b.blob_hash IS NOT NULL THEN 'content'
-               WHEN o.blob_hash IS NULL 
-                    AND t.blob_hash IS NOT NULL THEN 'deleted_modified'
-               ELSE 'add_add'
+               WHEN o.blob_hash IS NULL AND t.blob_hash IS NOT NULL THEN 'deleted_modified'
+               WHEN t.blob_hash IS NULL AND o.blob_hash IS NOT NULL THEN 'modified_deleted'
+               WHEN b.blob_hash IS NULL THEN 'add_add'
+               ELSE 'content'
            END as conflict_type
-    FROM (SELECT path FROM our_files 
-          UNION SELECT path FROM their_files) f
+    FROM (SELECT our_files.path FROM our_files
+          UNION SELECT their_files.path FROM their_files) f
     LEFT JOIN our_files o ON f.path = o.path
     LEFT JOIN their_files t ON f.path = t.path
     LEFT JOIN base_files b ON f.path = b.path
-    WHERE (o.blob_hash != t.blob_hash OR o.blob_hash IS NULL OR t.blob_hash IS NULL)
-    AND NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
+    WHERE NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
 END;$$ LANGUAGE plpgsql;

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -859,12 +859,21 @@ CREATE OR REPLACE FUNCTION pggit.reset_file(
     p_commit TEXT DEFAULT 'HEAD'
 ) RETURNS VOID SET search_path = pggit, public AS $$
 DECLARE
+    v_commit_hash TEXT;
     v_tree_hash TEXT;
     v_blob_hash TEXT;
 BEGIN
+    -- Resolve p_commit: a ref name (e.g. the default 'HEAD' or a branch) maps to
+    -- its commit hash; otherwise it is already a commit hash. Without this the
+    -- default 'HEAD' is looked up as a literal commit hash, finds nothing, and
+    -- the file is wrongly dropped from the index instead of restored.
+    SELECT commit_hash INTO v_commit_hash
+    FROM pggit.refs WHERE repo_id = p_repo_id AND name = p_commit;
+    v_commit_hash := COALESCE(v_commit_hash, p_commit);
+
     -- Get tree from commit
     SELECT tree_hash INTO v_tree_hash
-    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_commit;
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = v_commit_hash;
     
     -- Get blob hash from tree
     SELECT (e->>'hash')::TEXT INTO v_blob_hash
@@ -1154,6 +1163,21 @@ CREATE TABLE pggit.merge_conflicts (
     FOREIGN KEY (repo_id, resolution_blob_hash) REFERENCES pggit.blobs(repo_id, hash)
 );
 
+-- A three-way merge of a single path needs no manual resolution when either
+-- side is unchanged from the base (take the other side) or both sides resolve
+-- to the same blob. Anything else is a genuine conflict. NULL means the file is
+-- absent on that side (added or deleted), so IS [NOT] DISTINCT FROM is used to
+-- compare hashes without tripping over NULL semantics.
+CREATE OR REPLACE FUNCTION pggit.can_auto_merge(
+    p_our_hash TEXT,
+    p_their_hash TEXT,
+    p_base_hash TEXT
+) RETURNS BOOLEAN IMMUTABLE SET search_path = pggit, public AS $$
+    SELECT p_our_hash IS NOT DISTINCT FROM p_their_hash   -- both sides agree
+        OR p_our_hash IS NOT DISTINCT FROM p_base_hash    -- we didn't change it
+        OR p_their_hash IS NOT DISTINCT FROM p_base_hash; -- they didn't change it
+$$ LANGUAGE sql;
+
 CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
     p_repo_id INTEGER,
     p_our_commit TEXT,
@@ -1164,38 +1188,50 @@ CREATE OR REPLACE FUNCTION pggit.detect_conflicts(
 ) SET search_path = pggit, public AS $$
 DECLARE
     v_base_commit TEXT;
+    v_our_tree TEXT;
+    v_their_tree TEXT;
+    v_base_tree TEXT;
 BEGIN
-    -- Find merge base
-    v_base_commit := pggit.find_merge_base(p_repo_id, p_our_commit, p_their_commit);
-    
+    -- Find merge base (find_merge_base identifies the repo from the commits).
+    v_base_commit := pggit.find_merge_base(p_our_commit, p_their_commit);
+
+    -- Resolve each commit to its tree. get_tree_files expects a tree hash, not
+    -- a commit hash. A missing/NULL commit yields a NULL tree, i.e. no files.
+    SELECT tree_hash INTO v_our_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_our_commit;
+    SELECT tree_hash INTO v_their_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = p_their_commit;
+    SELECT tree_hash INTO v_base_tree
+    FROM pggit.commits WHERE repo_id = p_repo_id AND hash = v_base_commit;
+
     RETURN QUERY
+    -- Columns are qualified via the function alias: the RETURNS TABLE OUT
+    -- parameter "path" would otherwise shadow the unqualified column name.
     WITH our_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(p_our_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_our_tree) gtf
     ),
     their_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(p_their_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_their_tree) gtf
     ),
     base_files AS (
-        SELECT path, blob_hash
-        FROM pggit.get_tree_files(v_base_commit)
+        SELECT gtf.path, gtf.blob_hash
+        FROM pggit.get_tree_files(p_repo_id, v_base_tree) gtf
     )
     SELECT DISTINCT f.path,
            CASE
-               WHEN o.blob_hash != t.blob_hash 
-                    AND b.blob_hash IS NOT NULL THEN 'content'
-               WHEN o.blob_hash IS NULL 
-                    AND t.blob_hash IS NOT NULL THEN 'deleted_modified'
-               ELSE 'add_add'
+               WHEN o.blob_hash IS NULL AND t.blob_hash IS NOT NULL THEN 'deleted_modified'
+               WHEN t.blob_hash IS NULL AND o.blob_hash IS NOT NULL THEN 'modified_deleted'
+               WHEN b.blob_hash IS NULL THEN 'add_add'
+               ELSE 'content'
            END as conflict_type
-    FROM (SELECT path FROM our_files 
-          UNION SELECT path FROM their_files) f
+    FROM (SELECT our_files.path FROM our_files
+          UNION SELECT their_files.path FROM their_files) f
     LEFT JOIN our_files o ON f.path = o.path
     LEFT JOIN their_files t ON f.path = t.path
     LEFT JOIN base_files b ON f.path = b.path
-    WHERE (o.blob_hash != t.blob_hash OR o.blob_hash IS NULL OR t.blob_hash IS NULL)
-    AND NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
+    WHERE NOT pggit.can_auto_merge(o.blob_hash, t.blob_hash, b.blob_hash);
 END;$$ LANGUAGE plpgsql;
 
 -- ===== sql/functions/014-https.sql =====
@@ -3147,15 +3183,18 @@ BEGIN
                e->>'type' as type
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_tree_hash
-        
+        WHERE repo_id = p_repo_id AND hash = p_tree_hash
+
         UNION ALL
-        
-        SELECT tf.path || '/' || e->>'name',
+
+        -- Parenthesize (e->>'name'): the || operator binds tighter than ->>,
+        -- so without parens this parses as (tf.path || '/' || e) ->> 'name'
+        -- and fails to type-check.
+        SELECT tf.path || '/' || (e->>'name'),
                e->>'hash',
                e->>'type'
         FROM tree_files tf
-        JOIN trees t ON tf.hash = t.hash,
+        JOIN trees t ON t.repo_id = p_repo_id AND tf.hash = t.hash,
         jsonb_array_elements(t.entries) e
         WHERE tf.type = 'tree'
     )

--- a/sql/pgit-sparse.sql
+++ b/sql/pgit-sparse.sql
@@ -91,15 +91,18 @@ BEGIN
                e->>'type' as type
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_tree_hash
-        
+        WHERE repo_id = p_repo_id AND hash = p_tree_hash
+
         UNION ALL
-        
-        SELECT tf.path || '/' || e->>'name',
+
+        -- Parenthesize (e->>'name'): the || operator binds tighter than ->>,
+        -- so without parens this parses as (tf.path || '/' || e) ->> 'name'
+        -- and fails to type-check.
+        SELECT tf.path || '/' || (e->>'name'),
                e->>'hash',
                e->>'type'
         FROM tree_files tf
-        JOIN trees t ON tf.hash = t.hash,
+        JOIN trees t ON t.repo_id = p_repo_id AND tf.hash = t.hash,
         jsonb_array_elements(t.entries) e
         WHERE tf.type = 'tree'
     )

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -7,8 +7,10 @@ test/sql/branch_test.sql
 test/sql/commit_test.sql
 test/sql/diff_test.sql
 test/sql/merge_test.sql
+test/sql/merge_conflicts_test.sql
 test/sql/remote_test.sql
 test/sql/advanced_test.sql
+test/sql/reset_test.sql
 test/sql/search_path_qualification_test.sql
 test/sql/gc_test.sql
 test/sql/https_fetch_test.sql

--- a/test/sql/merge_conflicts_test.sql
+++ b/test/sql/merge_conflicts_test.sql
@@ -1,0 +1,110 @@
+-- Path: /test/sql/merge_conflicts_test.sql
+-- pg_git merge conflict detection tests
+
+BEGIN;
+
+SELECT plan(8);
+
+-- can_auto_merge unit checks (three-way, blob hashes stand in for content).
+SELECT ok(
+    pggit.can_auto_merge('a', 'a', 'a'),
+    'can_auto_merge: no side changed'
+);
+SELECT ok(
+    pggit.can_auto_merge('a', 'b', 'a'),
+    'can_auto_merge: only their side changed (take theirs)'
+);
+SELECT ok(
+    pggit.can_auto_merge('b', 'a', 'a'),
+    'can_auto_merge: only our side changed (take ours)'
+);
+SELECT ok(
+    pggit.can_auto_merge('c', 'c', 'a'),
+    'can_auto_merge: both sides made the same change'
+);
+SELECT ok(
+    NOT pggit.can_auto_merge('b', 'c', 'a'),
+    'can_auto_merge: both sides changed differently -> conflict'
+);
+
+-- Build a diverging history off a shared base:
+--   base:   shared.txt='base', common.txt='keep'
+--   ours:   shared.txt='ours',  common.txt unchanged, ours.txt added
+--   theirs: shared.txt='their', common.txt unchanged, theirs.txt added
+SELECT pggit.init_repository('conflict_repo', '/conflict/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'shared.txt', 'base'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'common.txt', 'keep'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'base') AS base \gset
+SELECT set_config('vars.base', :'base', false);
+
+-- ours
+SELECT pggit.create_branch((current_setting('vars.repo_id')::int), 'ours', current_setting('vars.base'));
+SELECT pggit.checkout_branch((current_setting('vars.repo_id')::int), 'ours');
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'shared.txt', 'ours'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'common.txt', 'keep'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'ours.txt', 'o'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'ours') AS ours \gset
+SELECT set_config('vars.ours', :'ours', false);
+
+-- theirs (branch off the base again)
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.base'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'shared.txt', 'their'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'common.txt', 'keep'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'theirs.txt', 't'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'theirs') AS theirs \gset
+SELECT set_config('vars.theirs', :'theirs', false);
+
+-- Only shared.txt genuinely conflicts. common.txt is unchanged on both sides,
+-- and ours.txt / theirs.txt are one-sided additions (auto-mergeable).
+SELECT results_eq(
+    $$SELECT path, conflict_type
+      FROM pggit.detect_conflicts(
+          (current_setting('vars.repo_id')::int),
+          current_setting('vars.ours'),
+          current_setting('vars.theirs'))
+      ORDER BY path$$,
+    $$VALUES ('shared.txt', 'content')$$,
+    'detect_conflicts reports only the divergently-edited file'
+);
+
+-- Identical commits produce no conflicts.
+SELECT is_empty(
+    $$SELECT * FROM pggit.detect_conflicts(
+          (current_setting('vars.repo_id')::int),
+          current_setting('vars.ours'),
+          current_setting('vars.ours'))$$,
+    'detect_conflicts finds nothing when both sides are identical'
+);
+
+-- add/add: two branches independently add the same path with different content.
+SELECT pggit.checkout_branch((current_setting('vars.repo_id')::int), 'ours');
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'shared.txt', 'ours'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'common.txt', 'keep'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'ours.txt', 'o'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'new.txt', 'ours-new'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'ours+new') AS ours2 \gset
+SELECT set_config('vars.ours2', :'ours2', false);
+
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.theirs'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'shared.txt', 'their'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'common.txt', 'keep'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'theirs.txt', 't'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'new.txt', 'their-new'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'their+new') AS theirs2 \gset
+SELECT set_config('vars.theirs2', :'theirs2', false);
+
+SELECT results_eq(
+    $$SELECT conflict_type
+      FROM pggit.detect_conflicts(
+          (current_setting('vars.repo_id')::int),
+          current_setting('vars.ours2'),
+          current_setting('vars.theirs2'))
+      WHERE path = 'new.txt'$$,
+    $$VALUES ('add_add')$$,
+    'detect_conflicts classifies an independent same-path add as add_add'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/sql/reset_test.sql
+++ b/test/sql/reset_test.sql
@@ -1,0 +1,91 @@
+-- Path: /test/sql/reset_test.sql
+-- pg_git reset tests
+
+BEGIN;
+
+SELECT plan(7);
+
+-- Setup: repository with two commits on a single line of history.
+SELECT pggit.init_repository('reset_repo', '/reset/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+
+-- First commit: a.txt = 'hello'
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'hello'::bytea)
+    AS blob_v1 \gset
+SELECT set_config('vars.blob_v1', :'blob_v1', false);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'first') AS c1 \gset
+SELECT set_config('vars.c1', :'c1', false);
+
+-- Second commit: a.txt = 'world'
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'world'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'second') AS c2 \gset
+SELECT set_config('vars.c2', :'c2', false);
+
+-- reset_soft: moves HEAD to the target commit.
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.c1'));
+SELECT is(
+    (SELECT commit_hash FROM refs
+     WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'),
+    current_setting('vars.c1'),
+    'reset_soft moves HEAD to the target commit'
+);
+
+-- reset_mixed: moves HEAD and clears the staging index.
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.c2'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'staged.txt', 'wip'::bytea);
+SELECT pggit.reset_mixed((current_setting('vars.repo_id')::int), current_setting('vars.c1'));
+SELECT is(
+    (SELECT commit_hash FROM refs
+     WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'),
+    current_setting('vars.c1'),
+    'reset_mixed moves HEAD to the target commit'
+);
+SELECT is_empty(
+    $$SELECT 1 FROM index_entries WHERE repo_id = (current_setting('vars.repo_id')::int)$$,
+    'reset_mixed clears the staging index'
+);
+
+-- reset_file with the default target ('HEAD'): a staged modification is reverted
+-- to the blob recorded in HEAD's commit. Regression test: the default used to be
+-- treated as a literal commit hash, so the entry was dropped instead of restored.
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.c1'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'CHANGED'::bytea);
+SELECT pggit.reset_file((current_setting('vars.repo_id')::int), 'a.txt');
+SELECT is(
+    (SELECT blob_hash FROM index_entries
+     WHERE repo_id = (current_setting('vars.repo_id')::int) AND path = 'a.txt'),
+    current_setting('vars.blob_v1'),
+    'reset_file with default HEAD restores the committed blob'
+);
+
+-- reset_file with the default target drops an index entry absent from HEAD's tree.
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'ghost.txt', 'boo'::bytea);
+SELECT pggit.reset_file((current_setting('vars.repo_id')::int), 'ghost.txt');
+SELECT is_empty(
+    $$SELECT 1 FROM index_entries
+      WHERE repo_id = (current_setting('vars.repo_id')::int) AND path = 'ghost.txt'$$,
+    'reset_file removes an index entry not present in the target commit'
+);
+
+-- reset_file accepts an explicit commit hash and restores from that commit.
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'CHANGED-AGAIN'::bytea);
+SELECT pggit.reset_file(
+    (current_setting('vars.repo_id')::int), 'a.txt', current_setting('vars.c1'));
+SELECT is(
+    (SELECT blob_hash FROM index_entries
+     WHERE repo_id = (current_setting('vars.repo_id')::int) AND path = 'a.txt'),
+    current_setting('vars.blob_v1'),
+    'reset_file restores from an explicit commit hash'
+);
+
+-- A ref name that does not resolve is treated as a literal commit hash; an
+-- unknown hash yields no tree, so the file is dropped rather than erroring.
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'CHANGED'::bytea);
+SELECT lives_ok(
+    $$SELECT pggit.reset_file(
+        (current_setting('vars.repo_id')::int), 'a.txt', 'deadbeef')$$,
+    'reset_file tolerates an unresolvable target'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Continues the effort to get pg_git behaving to spec and testably correct. On top of the prior test-suite work carried on this branch, this fixes three latent correctness bugs in features the README lists as **Implemented ✅** but that had no test coverage — two of them were completely non-functional at runtime.

## Bugs fixed

- **`reset_file` dropped files instead of restoring them.** The default target `'HEAD'` was queried as a *literal* commit hash (`commits WHERE hash = 'HEAD'`), matched nothing, and the file was deleted from the index rather than reverted to its committed blob. Now resolves ref names (`HEAD`, branches) to their commit hash, falling back to a literal hash.

- **`get_tree_files` failed to plan on every call.** `tf.path || '/' || e->>'name'` parsed as `(… || e) ->> 'name'` because `||` binds tighter than `->>`, raising `operator does not exist: text ->> unknown`. Parenthesized the accessor and scoped the tree lookups by `repo_id` (identical tree hashes across repos would otherwise duplicate rows).

- **`detect_conflicts` could not run at all.** It called `find_merge_base` with the wrong arity, passed *commit* hashes to `get_tree_files` (which expects *tree* hashes), and depended on a `can_auto_merge` helper that was never defined. Rewrote it to resolve commits→trees, added the missing `can_auto_merge` three-way helper, and qualified columns so the `RETURNS TABLE` OUT parameter `path` no longer shadows them.

## Tests

- `test/sql/reset_test.sql` — `reset_soft`/`reset_mixed`/`reset_file`, including the default-`HEAD` regression, explicit-commit restore, and removal of entries absent from the target tree.
- `test/sql/merge_conflicts_test.sql` — `can_auto_merge` truth table plus `detect_conflicts` over a diverging history (content conflict, unchanged files and one-sided adds excluded, identical commits, add/add).
- Both wired into the core suite (`makefile` + `manifest.txt`).

## Verification

Built and installed against PostgreSQL 16 with `pgcrypto`/`pg_trgm`/`plpython3u`/`pgtap`. Full suite green:

- `make test-core` — 13 files, 95 tests, PASS
- `RUN_INTEGRATION=1 RUN_PERF=1 make test-all` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah3utcCy6BGmEZ4kG9XEGS)_