### PR TITLE
Fix runtime errors in plumbing/traversal commands (cat_file, ls_tree, rev_list, merge_base, bisect)

### DIFF
--- a/makefile
+++ b/makefile
@@ -63,6 +63,7 @@ CORE_TESTS := \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
        test/sql/reset_test.sql \
+       test/sql/plumbing_test.sql \
        test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \
        test/sql/optimize_indexes_test.sql

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -2093,9 +2093,9 @@ BEGIN
     -- Find middle commit
     SELECT hash INTO v_mid_commit
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
-        FROM pggit.rev_list(p_bad_commit, ARRAY[p_good_commit])
+        FROM pggit.rev_list(p_repo_id, p_bad_commit, ARRAY[p_good_commit])
     ) commits
     WHERE rn = total/2;
     
@@ -2128,9 +2128,10 @@ BEGIN
     -- Find next commit to test
     SELECT hash INTO v_next
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
         FROM pggit.rev_list(
+            p_repo_id,
             (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
             (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )
@@ -2166,9 +2167,10 @@ BEGIN
     -- Find next commit to test
     SELECT hash INTO v_next
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
         FROM pggit.rev_list(
+            p_repo_id,
             (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
             (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )
@@ -2596,11 +2598,12 @@ CREATE OR REPLACE FUNCTION pggit.cat_file(
     content TEXT
 ) SET search_path = pggit, public AS $$
 BEGIN
-    -- Try blobs
+    -- Try blobs. Columns are table-qualified because the RETURNS TABLE OUT
+    -- parameter "content" would otherwise shadow blobs.content.
     RETURN QUERY
     SELECT 'blob'::TEXT,
-           octet_length(content)::BIGINT,
-           encode(content, 'escape')
+           octet_length(blobs.content)::BIGINT,
+           encode(blobs.content, 'escape')
     FROM blobs WHERE repo_id = p_repo_id AND hash = p_hash
     AND (p_type IS NULL OR p_type = 'blob');
     
@@ -2690,9 +2693,11 @@ BEGIN
             jsonb_array_elements(t.entries) se
             WHERE te.type = 'tree'
         )
-        SELECT mode, type, hash, path
+        -- Qualify with the CTE name: mode/type/hash/path are also RETURNS TABLE
+        -- OUT parameters and would otherwise be ambiguous.
+        SELECT tree_entries.mode, tree_entries.type, tree_entries.hash, tree_entries.path
         FROM tree_entries
-        ORDER BY path;
+        ORDER BY tree_entries.path;
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -2702,8 +2707,9 @@ CREATE OR REPLACE FUNCTION pggit.merge_base(
     p_commit1 TEXT,
     p_commit2 TEXT
 ) RETURNS TEXT SET search_path = pggit, public AS $$
-    -- Reuse existing merge base finding function
-    SELECT pggit.find_merge_base(p_repo_id, p_commit1, p_commit2);
+    -- Reuse existing merge base finding function. find_merge_base identifies the
+    -- repository from the commit hashes themselves, so it takes only two args.
+    SELECT pggit.find_merge_base(p_commit1, p_commit2);
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION pggit.rev_list(
@@ -2717,8 +2723,9 @@ CREATE OR REPLACE FUNCTION pggit.rev_list(
 BEGIN
     RETURN QUERY
     WITH RECURSIVE commit_list AS (
-        -- Start commit
-        SELECT hash,
+        -- Start commit. commits.hash is qualified because "hash" is also a
+        -- RETURNS TABLE OUT parameter and would otherwise be ambiguous.
+        SELECT commits.hash,
                jsonb_build_object(
                    'tree', tree_hash,
                    'parent', parent_hash,
@@ -2727,7 +2734,7 @@ BEGIN
                    'timestamp', timestamp
                ) as commit_data
         FROM commits
-        WHERE repo_id = p_repo_id AND hash = p_start_commit
+        WHERE repo_id = p_repo_id AND commits.hash = p_start_commit
         
         UNION
         

--- a/sql/pgit-extras.sql
+++ b/sql/pgit-extras.sql
@@ -104,9 +104,9 @@ BEGIN
     -- Find middle commit
     SELECT hash INTO v_mid_commit
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
-        FROM pggit.rev_list(p_bad_commit, ARRAY[p_good_commit])
+        FROM pggit.rev_list(p_repo_id, p_bad_commit, ARRAY[p_good_commit])
     ) commits
     WHERE rn = total/2;
     
@@ -139,9 +139,10 @@ BEGIN
     -- Find next commit to test
     SELECT hash INTO v_next
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
         FROM pggit.rev_list(
+            p_repo_id,
             (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
             (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )
@@ -177,9 +178,10 @@ BEGIN
     -- Find next commit to test
     SELECT hash INTO v_next
     FROM (
-        SELECT hash, ROW_NUMBER() OVER (ORDER BY timestamp) as rn,
+        SELECT hash, ROW_NUMBER() OVER (ORDER BY (commit_data->>'timestamp')::timestamptz) as rn,
                COUNT(*) OVER () as total
         FROM pggit.rev_list(
+            p_repo_id,
             (SELECT bad_commits[1] FROM pggit.bisect_state WHERE repo_id = p_repo_id),
             (SELECT good_commits FROM pggit.bisect_state WHERE repo_id = p_repo_id)
         )

--- a/sql/pgit-plumbing.sql
+++ b/sql/pgit-plumbing.sql
@@ -11,11 +11,12 @@ CREATE OR REPLACE FUNCTION pggit.cat_file(
     content TEXT
 ) SET search_path = pggit, public AS $$
 BEGIN
-    -- Try blobs
+    -- Try blobs. Columns are table-qualified because the RETURNS TABLE OUT
+    -- parameter "content" would otherwise shadow blobs.content.
     RETURN QUERY
     SELECT 'blob'::TEXT,
-           octet_length(content)::BIGINT,
-           encode(content, 'escape')
+           octet_length(blobs.content)::BIGINT,
+           encode(blobs.content, 'escape')
     FROM blobs WHERE repo_id = p_repo_id AND hash = p_hash
     AND (p_type IS NULL OR p_type = 'blob');
     
@@ -105,9 +106,11 @@ BEGIN
             jsonb_array_elements(t.entries) se
             WHERE te.type = 'tree'
         )
-        SELECT mode, type, hash, path
+        -- Qualify with the CTE name: mode/type/hash/path are also RETURNS TABLE
+        -- OUT parameters and would otherwise be ambiguous.
+        SELECT tree_entries.mode, tree_entries.type, tree_entries.hash, tree_entries.path
         FROM tree_entries
-        ORDER BY path;
+        ORDER BY tree_entries.path;
     END IF;
 END;
 $$ LANGUAGE plpgsql;
@@ -117,8 +120,9 @@ CREATE OR REPLACE FUNCTION pggit.merge_base(
     p_commit1 TEXT,
     p_commit2 TEXT
 ) RETURNS TEXT SET search_path = pggit, public AS $$
-    -- Reuse existing merge base finding function
-    SELECT pggit.find_merge_base(p_repo_id, p_commit1, p_commit2);
+    -- Reuse existing merge base finding function. find_merge_base identifies the
+    -- repository from the commit hashes themselves, so it takes only two args.
+    SELECT pggit.find_merge_base(p_commit1, p_commit2);
 $$ LANGUAGE sql;
 
 CREATE OR REPLACE FUNCTION pggit.rev_list(
@@ -132,8 +136,9 @@ CREATE OR REPLACE FUNCTION pggit.rev_list(
 BEGIN
     RETURN QUERY
     WITH RECURSIVE commit_list AS (
-        -- Start commit
-        SELECT hash,
+        -- Start commit. commits.hash is qualified because "hash" is also a
+        -- RETURNS TABLE OUT parameter and would otherwise be ambiguous.
+        SELECT commits.hash,
                jsonb_build_object(
                    'tree', tree_hash,
                    'parent', parent_hash,
@@ -142,7 +147,7 @@ BEGIN
                    'timestamp', timestamp
                ) as commit_data
         FROM commits
-        WHERE repo_id = p_repo_id AND hash = p_start_commit
+        WHERE repo_id = p_repo_id AND commits.hash = p_start_commit
         
         UNION
         

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -11,6 +11,7 @@ test/sql/merge_conflicts_test.sql
 test/sql/remote_test.sql
 test/sql/advanced_test.sql
 test/sql/reset_test.sql
+test/sql/plumbing_test.sql
 test/sql/search_path_qualification_test.sql
 test/sql/gc_test.sql
 test/sql/https_fetch_test.sql

--- a/test/sql/plumbing_test.sql
+++ b/test/sql/plumbing_test.sql
@@ -1,0 +1,92 @@
+-- Path: /test/sql/plumbing_test.sql
+-- pg_git plumbing/traversal command tests
+-- Regression coverage: these commands previously errored at runtime
+-- (ambiguous OUT-parameter columns; wrong-arity internal calls).
+
+BEGIN;
+
+SELECT plan(9);
+
+SELECT pggit.init_repository('plumb_repo', '/plumb/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+
+-- Two commits on one line of history.
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', E'l1\nl2'::bytea)
+    AS blob1 \gset
+SELECT set_config('vars.blob1', :'blob1', false);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c1') AS c1 \gset
+SELECT set_config('vars.c1', :'c1', false);
+
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', E'l1\nl2\nl3'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c2') AS c2 \gset
+SELECT set_config('vars.c2', :'c2', false);
+SELECT tree_hash AS tree2 FROM commits WHERE hash = :'c2' \gset
+SELECT set_config('vars.tree2', :'tree2', false);
+
+-- cat_file: a staged blob is reported as a blob with its content.
+SELECT is(
+    (SELECT object_type FROM pggit.cat_file(
+        (current_setting('vars.repo_id')::int), current_setting('vars.blob1'))),
+    'blob',
+    'cat_file reports a blob object type'
+);
+SELECT is(
+    (SELECT content FROM pggit.cat_file(
+        (current_setting('vars.repo_id')::int), current_setting('vars.blob1'))),
+    E'l1\nl2',
+    'cat_file returns the blob content'
+);
+SELECT is(
+    (SELECT object_type FROM pggit.cat_file(
+        (current_setting('vars.repo_id')::int), current_setting('vars.c2'))),
+    'commit',
+    'cat_file reports a commit object type'
+);
+
+-- ls_tree (recursive): the tree holds a single blob entry, a.txt.
+SELECT results_eq(
+    $$SELECT type, path FROM pggit.ls_tree(
+        (current_setting('vars.repo_id')::int), current_setting('vars.tree2'), true)$$,
+    $$VALUES ('blob', 'a.txt')$$,
+    'ls_tree lists the tree entries'
+);
+
+-- rev_list: initial commit + c1 + c2 are reachable from c2.
+SELECT is(
+    (SELECT count(*)::int FROM pggit.rev_list(
+        (current_setting('vars.repo_id')::int), current_setting('vars.c2'))),
+    3,
+    'rev_list walks the full ancestry from a commit'
+);
+SELECT ok(
+    EXISTS (SELECT 1 FROM pggit.rev_list(
+        (current_setting('vars.repo_id')::int), current_setting('vars.c2')) rl
+        WHERE rl.hash = current_setting('vars.c1')),
+    'rev_list includes an ancestor commit'
+);
+
+-- merge_base: c1 is an ancestor of c2, so it is their merge base.
+SELECT is(
+    pggit.merge_base(
+        (current_setting('vars.repo_id')::int),
+        current_setting('vars.c1'),
+        current_setting('vars.c2')),
+    current_setting('vars.c1'),
+    'merge_base returns the common ancestor'
+);
+
+-- bisect commands are callable end-to-end (they consume rev_list).
+SELECT lives_ok(
+    $$SELECT pggit.bisect_start(
+        (current_setting('vars.repo_id')::int),
+        current_setting('vars.c2'),
+        current_setting('vars.c1'))$$,
+    'bisect_start runs without error'
+);
+SELECT lives_ok(
+    $$SELECT pggit.bisect_good((current_setting('vars.repo_id')::int))$$,
+    'bisect_good runs without error'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Five exported commands errored on **every** call and had no test coverage. Each was confirmed failing against a live PostgreSQL 16 build before the fix and passing after.

## Bugs fixed

- **`cat_file` / `ls_tree` / `rev_list`** — `column reference "…" is ambiguous`. A `RETURNS TABLE` OUT parameter (`content`, `mode`/`hash`, `hash`) shadowed an identically named table/CTE column. Qualified the references.

- **`merge_base`** — called `find_merge_base(p_repo_id, c1, c2)`, but that function takes two args (it derives the repo from the commit hashes). Dropped the extra argument.

- **`bisect_start` / `bisect_good` / `bisect_bad`** — called `rev_list` without its required `p_repo_id` (`function pggit.rev_list(text, text[]) does not exist`), and then ordered by a non-existent `timestamp` column. `rev_list` exposes the timestamp inside its `commit_data` JSONB, so ordering now uses `(commit_data->>'timestamp')::timestamptz`.

## Tests

`test/sql/plumbing_test.sql` (9 assertions) covers `cat_file` (blob + commit), `ls_tree` (recursive), `rev_list` (ancestry walk), `merge_base` (common ancestor), and the `bisect_start`/`bisect_good` entry points. Wired into the core suite via `makefile` + `manifest.txt`.

## Verification

`make test-core` — 14 files, PASS (full suite green against PostgreSQL 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah3utcCy6BGmEZ4kG9XEGS)_