### PR TITLE
Fix "column reference is ambiguous" errors in whatchanged, merge_trees and GPG verification

### DIFF
--- a/makefile
+++ b/makefile
@@ -63,6 +63,7 @@ CORE_TESTS := \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
        test/sql/reset_test.sql \
+       test/sql/ambiguous_column_regression_test.sql \
        test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \
        test/sql/optimize_indexes_test.sql

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -2419,7 +2419,8 @@ BEGIN
                'base' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_base_tree
+        -- trees.hash is qualified: "hash" is also a RETURNS TABLE OUT parameter.
+        WHERE trees.hash = p_base_tree
         
         UNION ALL
         
@@ -2429,7 +2430,7 @@ BEGIN
                'ours' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_ours_tree
+        WHERE trees.hash = p_ours_tree
         
         UNION ALL
         
@@ -2439,25 +2440,28 @@ BEGIN
                'theirs' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_theirs_tree
+        WHERE trees.hash = p_theirs_tree
     ),
     -- Analyze changes
     analysis AS (
-        SELECT DISTINCT path,
+        SELECT DISTINCT all_paths.path,
                bool_or(source = 'base') as in_base,
                bool_or(source = 'ours') as in_ours,
                bool_or(source = 'theirs') as in_theirs,
-               max(CASE WHEN source = 'base' THEN hash END) as base_hash,
-               max(CASE WHEN source = 'ours' THEN hash END) as ours_hash,
-               max(CASE WHEN source = 'theirs' THEN hash END) as theirs_hash,
-               max(CASE WHEN source = 'base' THEN mode END) as base_mode,
-               max(CASE WHEN source = 'ours' THEN mode END) as ours_mode,
-               max(CASE WHEN source = 'theirs' THEN mode END) as theirs_mode
+               -- all_paths.hash / all_paths.mode are qualified: "hash" and
+               -- "mode" are also RETURNS TABLE OUT parameters.
+               max(CASE WHEN source = 'base' THEN all_paths.hash END) as base_hash,
+               max(CASE WHEN source = 'ours' THEN all_paths.hash END) as ours_hash,
+               max(CASE WHEN source = 'theirs' THEN all_paths.hash END) as theirs_hash,
+               max(CASE WHEN source = 'base' THEN all_paths.mode END) as base_mode,
+               max(CASE WHEN source = 'ours' THEN all_paths.mode END) as ours_mode,
+               max(CASE WHEN source = 'theirs' THEN all_paths.mode END) as theirs_mode
         FROM all_paths
-        GROUP BY path
+        GROUP BY all_paths.path
     )
-    SELECT path,
-           CASE 
+    -- analysis.path is qualified: "path" is also a RETURNS TABLE OUT parameter.
+    SELECT analysis.path,
+           CASE
                WHEN NOT in_base AND in_ours AND in_theirs AND ours_hash != theirs_hash THEN 2  -- conflict
                WHEN in_base AND in_ours AND in_theirs AND base_hash != ours_hash AND base_hash != theirs_hash THEN 2  -- conflict
                ELSE 0  -- no conflict
@@ -3369,10 +3373,12 @@ BEGIN
     END IF;
 
     -- Get key info
+    -- gpg_keys.key_id is qualified: "key_id" is also a RETURNS TABLE OUT
+    -- parameter and would otherwise be an ambiguous column reference.
     SELECT * INTO v_key
     FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
-    AND key_id = v_signature.key_id;
+    AND gpg_keys.key_id = v_signature.key_id;
 
     IF NOT FOUND THEN
         RETURN QUERY
@@ -3483,11 +3489,12 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Get key info
+    -- Get key info. gpg_keys.key_id is qualified: "key_id" is also a RETURNS
+    -- TABLE OUT parameter and would otherwise be an ambiguous column reference.
     SELECT * INTO v_key
     FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
-    AND key_id = v_signature.key_id;
+    AND gpg_keys.key_id = v_signature.key_id;
 
     -- Check trust level
     IF p_require_trust_level IS NOT NULL AND 
@@ -3548,10 +3555,12 @@ DECLARE
     v_since_hash TEXT;
     v_until_hash TEXT;
 BEGIN
-    -- Resolve commit references
+    -- Resolve commit references. refs.commit_hash is qualified because
+    -- "commit_hash" is also a RETURNS TABLE OUT parameter, and the lookup is
+    -- scoped to this repository's HEAD rather than any repo's HEAD.
     IF p_until = 'HEAD' THEN
-        SELECT commit_hash INTO v_until_hash
-        FROM refs WHERE name = 'HEAD';
+        SELECT refs.commit_hash INTO v_until_hash
+        FROM refs WHERE refs.repo_id = p_repo_id AND name = 'HEAD';
     ELSE
         v_until_hash := p_until;
     END IF;
@@ -3559,11 +3568,12 @@ BEGIN
     -- Get commit history with changes
     RETURN QUERY
     WITH RECURSIVE commit_history AS (
-        -- Start from until commit
-        SELECT repo_id, hash, parent_hash, author, timestamp, message, tree_hash
-        FROM commits
-        WHERE repo_id = p_repo_id
-          AND hash = v_until_hash
+        -- Start from until commit. Columns are qualified because author,
+        -- timestamp and message are also RETURNS TABLE OUT parameters.
+        SELECT c.repo_id, c.hash, c.parent_hash, c.author, c.timestamp, c.message, c.tree_hash
+        FROM commits c
+        WHERE c.repo_id = p_repo_id
+          AND c.hash = v_until_hash
 
         UNION ALL
 
@@ -3616,7 +3626,7 @@ BEGIN
     )
     SELECT *
     FROM file_changes
-    ORDER BY timestamp DESC, commit_hash, path;
+    ORDER BY file_changes.timestamp DESC, file_changes.commit_hash, file_changes.path;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/sql/pgit-merge-tree.sql
+++ b/sql/pgit-merge-tree.sql
@@ -22,7 +22,8 @@ BEGIN
                'base' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_base_tree
+        -- trees.hash is qualified: "hash" is also a RETURNS TABLE OUT parameter.
+        WHERE trees.hash = p_base_tree
         
         UNION ALL
         
@@ -32,7 +33,7 @@ BEGIN
                'ours' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_ours_tree
+        WHERE trees.hash = p_ours_tree
         
         UNION ALL
         
@@ -42,25 +43,28 @@ BEGIN
                'theirs' as source
         FROM trees,
         jsonb_array_elements(entries) e
-        WHERE hash = p_theirs_tree
+        WHERE trees.hash = p_theirs_tree
     ),
     -- Analyze changes
     analysis AS (
-        SELECT DISTINCT path,
+        SELECT DISTINCT all_paths.path,
                bool_or(source = 'base') as in_base,
                bool_or(source = 'ours') as in_ours,
                bool_or(source = 'theirs') as in_theirs,
-               max(CASE WHEN source = 'base' THEN hash END) as base_hash,
-               max(CASE WHEN source = 'ours' THEN hash END) as ours_hash,
-               max(CASE WHEN source = 'theirs' THEN hash END) as theirs_hash,
-               max(CASE WHEN source = 'base' THEN mode END) as base_mode,
-               max(CASE WHEN source = 'ours' THEN mode END) as ours_mode,
-               max(CASE WHEN source = 'theirs' THEN mode END) as theirs_mode
+               -- all_paths.hash / all_paths.mode are qualified: "hash" and
+               -- "mode" are also RETURNS TABLE OUT parameters.
+               max(CASE WHEN source = 'base' THEN all_paths.hash END) as base_hash,
+               max(CASE WHEN source = 'ours' THEN all_paths.hash END) as ours_hash,
+               max(CASE WHEN source = 'theirs' THEN all_paths.hash END) as theirs_hash,
+               max(CASE WHEN source = 'base' THEN all_paths.mode END) as base_mode,
+               max(CASE WHEN source = 'ours' THEN all_paths.mode END) as ours_mode,
+               max(CASE WHEN source = 'theirs' THEN all_paths.mode END) as theirs_mode
         FROM all_paths
-        GROUP BY path
+        GROUP BY all_paths.path
     )
-    SELECT path,
-           CASE 
+    -- analysis.path is qualified: "path" is also a RETURNS TABLE OUT parameter.
+    SELECT analysis.path,
+           CASE
                WHEN NOT in_base AND in_ours AND in_theirs AND ours_hash != theirs_hash THEN 2  -- conflict
                WHEN in_base AND in_ours AND in_theirs AND base_hash != ours_hash AND base_hash != theirs_hash THEN 2  -- conflict
                ELSE 0  -- no conflict

--- a/sql/pgit-verify-commit.sql
+++ b/sql/pgit-verify-commit.sql
@@ -67,10 +67,12 @@ BEGIN
     END IF;
 
     -- Get key info
+    -- gpg_keys.key_id is qualified: "key_id" is also a RETURNS TABLE OUT
+    -- parameter and would otherwise be an ambiguous column reference.
     SELECT * INTO v_key
     FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
-    AND key_id = v_signature.key_id;
+    AND gpg_keys.key_id = v_signature.key_id;
 
     IF NOT FOUND THEN
         RETURN QUERY

--- a/sql/pgit-verify-tag.sql
+++ b/sql/pgit-verify-tag.sql
@@ -61,11 +61,12 @@ BEGIN
         RETURN;
     END IF;
 
-    -- Get key info
+    -- Get key info. gpg_keys.key_id is qualified: "key_id" is also a RETURNS
+    -- TABLE OUT parameter and would otherwise be an ambiguous column reference.
     SELECT * INTO v_key
     FROM pggit.gpg_keys
     WHERE repo_id = p_repo_id
-    AND key_id = v_signature.key_id;
+    AND gpg_keys.key_id = v_signature.key_id;
 
     -- Check trust level
     IF p_require_trust_level IS NOT NULL AND 

--- a/sql/pgit-whatchanged.sql
+++ b/sql/pgit-whatchanged.sql
@@ -22,10 +22,12 @@ DECLARE
     v_since_hash TEXT;
     v_until_hash TEXT;
 BEGIN
-    -- Resolve commit references
+    -- Resolve commit references. refs.commit_hash is qualified because
+    -- "commit_hash" is also a RETURNS TABLE OUT parameter, and the lookup is
+    -- scoped to this repository's HEAD rather than any repo's HEAD.
     IF p_until = 'HEAD' THEN
-        SELECT commit_hash INTO v_until_hash
-        FROM refs WHERE name = 'HEAD';
+        SELECT refs.commit_hash INTO v_until_hash
+        FROM refs WHERE refs.repo_id = p_repo_id AND name = 'HEAD';
     ELSE
         v_until_hash := p_until;
     END IF;
@@ -33,11 +35,12 @@ BEGIN
     -- Get commit history with changes
     RETURN QUERY
     WITH RECURSIVE commit_history AS (
-        -- Start from until commit
-        SELECT repo_id, hash, parent_hash, author, timestamp, message, tree_hash
-        FROM commits
-        WHERE repo_id = p_repo_id
-          AND hash = v_until_hash
+        -- Start from until commit. Columns are qualified because author,
+        -- timestamp and message are also RETURNS TABLE OUT parameters.
+        SELECT c.repo_id, c.hash, c.parent_hash, c.author, c.timestamp, c.message, c.tree_hash
+        FROM commits c
+        WHERE c.repo_id = p_repo_id
+          AND c.hash = v_until_hash
 
         UNION ALL
 
@@ -90,7 +93,7 @@ BEGIN
     )
     SELECT *
     FROM file_changes
-    ORDER BY timestamp DESC, commit_hash, path;
+    ORDER BY file_changes.timestamp DESC, file_changes.commit_hash, file_changes.path;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/test/sql/ambiguous_column_regression_test.sql
+++ b/test/sql/ambiguous_column_regression_test.sql
@@ -1,0 +1,105 @@
+-- Path: /test/sql/ambiguous_column_regression_test.sql
+-- Regression coverage for exported functions that previously raised
+-- "column reference ... is ambiguous" (a RETURNS TABLE OUT parameter shadowing
+-- an identically named table/CTE column): whatchanged, merge_trees,
+-- verify_commit, verify_tag, verify_all_tags.
+
+BEGIN;
+
+SELECT plan(8);
+
+SELECT pggit.init_repository('amb_repo', '/amb/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+
+-- Linear history: c1 then c2 (a.txt modified, b.txt added). keep.txt is part of
+-- the base so the merge_trees case below has a file that is unchanged on both
+-- sides (and must therefore be omitted from the conflict report).
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'one'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'keep.txt', 'k'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c1') AS c1 \gset
+SELECT set_config('vars.c1', :'c1', false);
+SELECT tree_hash AS base_tree FROM commits WHERE hash = :'c1' \gset
+SELECT set_config('vars.base_tree', :'base_tree', false);
+
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'two'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'b.txt', 'new'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c2') AS c2 \gset
+SELECT set_config('vars.c2', :'c2', false);
+
+-- whatchanged: reports file changes across history (previously errored).
+SELECT isnt_empty(
+    $$SELECT * FROM pggit.whatchanged((current_setting('vars.repo_id')::int))$$,
+    'whatchanged returns rows'
+);
+SELECT ok(
+    EXISTS (SELECT 1 FROM pggit.whatchanged((current_setting('vars.repo_id')::int)) w
+            WHERE w.path = 'b.txt' AND w.change_type = 'A'),
+    'whatchanged reports b.txt as added'
+);
+SELECT ok(
+    (SELECT bool_and(w.path = 'a.txt')
+     FROM pggit.whatchanged(
+         (current_setting('vars.repo_id')::int), NULL, 'HEAD', ARRAY['a.txt']) w),
+    'whatchanged honours a path filter'
+);
+
+-- merge_trees: divergent edits to a.txt conflict; keep.txt is unchanged.
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.c1'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'ours'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'keep.txt', 'k'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'ours') AS ours \gset
+SELECT tree_hash AS ours_tree FROM commits WHERE hash = :'ours' \gset
+SELECT set_config('vars.ours_tree', :'ours_tree', false);
+
+SELECT pggit.reset_soft((current_setting('vars.repo_id')::int), current_setting('vars.c1'));
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'theirs'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'keep.txt', 'k'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'theirs') AS theirs \gset
+SELECT tree_hash AS theirs_tree FROM commits WHERE hash = :'theirs' \gset
+SELECT set_config('vars.theirs_tree', :'theirs_tree', false);
+
+SELECT results_eq(
+    $$SELECT path, stage, status FROM pggit.merge_trees(
+        current_setting('vars.base_tree'),
+        current_setting('vars.ours_tree'),
+        current_setting('vars.theirs_tree'))$$,
+    $$VALUES ('a.txt', 2, 'both modified')$$,
+    'merge_trees flags the divergent file and omits the unchanged one'
+);
+
+-- GPG verification: sign a commit and a tag, then verify.
+SELECT pggit.add_gpg_key(
+    (current_setting('vars.repo_id')::int), 'KEY1', 'PUBKEY', 'tester <t@e>', 'full');
+SELECT pggit.sign_commit(
+    (current_setting('vars.repo_id')::int), current_setting('vars.c1'), 'KEY1', 'SIG');
+SELECT pggit.create_tag(
+    (current_setting('vars.repo_id')::int), 'v1', current_setting('vars.c1'), 'tester', 'msg');
+SELECT pggit.sign_tag((current_setting('vars.repo_id')::int), 'v1', 'KEY1', 'SIG');
+
+SELECT results_eq(
+    $$SELECT is_valid, key_id FROM pggit.verify_commit(
+        (current_setting('vars.repo_id')::int), current_setting('vars.c1'))$$,
+    $$VALUES (true, 'KEY1')$$,
+    'verify_commit validates a signed commit'
+);
+SELECT results_eq(
+    $$SELECT is_valid, verification_message FROM pggit.verify_commit(
+        (current_setting('vars.repo_id')::int), current_setting('vars.c2'))$$,
+    $$VALUES (false, 'No signature found')$$,
+    'verify_commit reports an unsigned commit as invalid'
+);
+SELECT is(
+    (SELECT is_valid FROM pggit.verify_tag(
+        (current_setting('vars.repo_id')::int), 'v1')),
+    true,
+    'verify_tag validates a signed tag'
+);
+SELECT results_eq(
+    $$SELECT tag_name, is_valid FROM pggit.verify_all_tags(
+        (current_setting('vars.repo_id')::int))$$,
+    $$VALUES ('v1', true)$$,
+    'verify_all_tags reports every tag'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -11,6 +11,7 @@ test/sql/merge_conflicts_test.sql
 test/sql/remote_test.sql
 test/sql/advanced_test.sql
 test/sql/reset_test.sql
+test/sql/ambiguous_column_regression_test.sql
 test/sql/search_path_qualification_test.sql
 test/sql/gc_test.sql
 test/sql/https_fetch_test.sql


### PR DESCRIPTION
## Summary

Five more exported functions errored on **every** call because a `RETURNS TABLE` OUT parameter shadowed an identically named table/CTE column, and PL/pgSQL couldn't disambiguate. None had test coverage. Each was confirmed failing on a live PostgreSQL 16 build before the fix.

## Bugs fixed

| Function | Shadowed name(s) | Error |
|----------|------------------|-------|
| `whatchanged` | `author`, `timestamp`, `message`, `commit_hash` | `column reference "…" is ambiguous` |
| `merge_trees` | `path`, `hash`, `mode` | `column reference "hash" is ambiguous` |
| `verify_commit` | `key_id` | `column reference "key_id" is ambiguous` |
| `verify_tag` | `key_id` | `column reference "key_id" is ambiguous` |
| `verify_all_tags` | (via `verify_tag`) | propagated failure |

Each fix qualifies the shadowed reference with its table/CTE name. `whatchanged` also resolved `'HEAD'` against *any* repository's HEAD (`SELECT commit_hash FROM refs WHERE name = 'HEAD'`); it is now scoped to the target repository.

## Tests

`test/sql/ambiguous_column_regression_test.sql` (8 assertions): `whatchanged` history listing + path filter, a three-way `merge_trees` with a genuine `both modified` conflict (and an unchanged file correctly omitted), and signed/unsigned `verify_commit`, `verify_tag`, `verify_all_tags`. Wired into the core suite.

## Verification

`make test-core` — PASS (full suite green against PostgreSQL 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah3utcCy6BGmEZ4kG9XEGS)_