### PR TITLE
Implement revert's missing apply_inverse_diff helper

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,6 +62,7 @@ CORE_TESTS := \
        test/sql/merge_conflicts_test.sql \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
+       test/sql/revert_test.sql \
        test/sql/reset_test.sql \
        test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -2024,6 +2024,62 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Produce a new tree by taking p_onto_tree and reversing the change that turned
+-- p_old_tree into p_new_tree (the old->new delta). This is the tree-level core of
+-- a revert: for each path the delta touched, a file it added is removed, and a
+-- file it modified or deleted is restored to its p_old_tree contents. Paths the
+-- delta did not touch are carried over from p_onto_tree unchanged.
+CREATE OR REPLACE FUNCTION pggit.apply_inverse_diff(
+    p_repo_id INTEGER,
+    p_onto_tree TEXT,
+    p_old_tree TEXT,
+    p_new_tree TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    WITH onto_entries AS (
+        SELECT e->>'name' AS name, e AS entry
+        FROM pggit.trees t, jsonb_array_elements(t.entries) e
+        WHERE t.repo_id = p_repo_id AND t.hash = p_onto_tree
+    ),
+    old_entries AS (
+        SELECT e->>'name' AS name, e AS entry
+        FROM pggit.trees t, jsonb_array_elements(t.entries) e
+        WHERE t.repo_id = p_repo_id AND t.hash = p_old_tree
+    ),
+    delta AS (
+        SELECT d.change_type, d.path
+        FROM pggit.diff_trees(p_repo_id, p_old_tree, p_new_tree) d
+    ),
+    merged AS (
+        -- Carry over onto entries, but drop paths the delta added (reverting an
+        -- addition removes the file) and restore old contents for modified paths.
+        SELECT o.name,
+               CASE WHEN dl.change_type = 'modified'
+                        THEN (SELECT oe.entry FROM old_entries oe WHERE oe.name = o.name)
+                    ELSE o.entry
+               END AS entry
+        FROM onto_entries o
+        LEFT JOIN delta dl ON dl.path = o.name
+        WHERE dl.change_type IS DISTINCT FROM 'added'
+
+        UNION ALL
+
+        -- Restore files the delta deleted (present in old, absent in new) that
+        -- are not already present in the onto tree.
+        SELECT oe.name, oe.entry
+        FROM delta dl
+        JOIN old_entries oe ON oe.name = dl.path
+        WHERE dl.change_type = 'deleted'
+          AND NOT EXISTS (SELECT 1 FROM onto_entries o2 WHERE o2.name = dl.path)
+    )
+    SELECT jsonb_agg(entry ORDER BY name) INTO v_result FROM merged;
+
+    RETURN pggit.create_tree(p_repo_id, COALESCE(v_result, '[]'::jsonb));
+END;
+$$ LANGUAGE plpgsql;
+
 -- Revert implementation
 CREATE OR REPLACE FUNCTION pggit.revert(
     p_repo_id INTEGER,
@@ -2032,20 +2088,28 @@ CREATE OR REPLACE FUNCTION pggit.revert(
 DECLARE
     v_parent_tree TEXT;
     v_commit_tree TEXT;
+    v_head_tree TEXT;
     v_new_tree TEXT;
     v_new_commit TEXT;
     v_message TEXT;
 BEGIN
-    -- Get trees and message
+    -- Get the reverted commit's tree, its parent's tree, and its message.
     SELECT tree_hash, message,
            (SELECT tree_hash FROM commits WHERE repo_id = p_repo_id AND hash = c.parent_hash)
     INTO v_commit_tree, v_message, v_parent_tree
     FROM commits c
     WHERE c.repo_id = p_repo_id AND hash = p_commit_hash;
-    
-    -- Create inverse diff
-    v_new_tree := pggit.apply_inverse_diff(v_parent_tree, v_commit_tree);
-    
+
+    -- The revert applies on top of the current HEAD tree.
+    SELECT c.tree_hash INTO v_head_tree
+    FROM refs r
+    JOIN commits c ON c.repo_id = r.repo_id AND c.hash = r.commit_hash
+    WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
+
+    -- Reverse the parent->commit change onto HEAD.
+    v_new_tree := pggit.apply_inverse_diff(
+        p_repo_id, v_head_tree, v_parent_tree, v_commit_tree);
+
     -- Create revert commit
     v_new_commit := pggit.create_commit(
         p_repo_id,
@@ -2054,12 +2118,12 @@ BEGIN
         current_user,
         'Revert "' || v_message || '"'
     );
-    
+
     -- Update HEAD
     UPDATE refs
     SET commit_hash = v_new_commit
     WHERE repo_id = p_repo_id AND name = 'HEAD';
-    
+
     RETURN v_new_commit;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/pgit-extras.sql
+++ b/sql/pgit-extras.sql
@@ -35,6 +35,62 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+-- Produce a new tree by taking p_onto_tree and reversing the change that turned
+-- p_old_tree into p_new_tree (the old->new delta). This is the tree-level core of
+-- a revert: for each path the delta touched, a file it added is removed, and a
+-- file it modified or deleted is restored to its p_old_tree contents. Paths the
+-- delta did not touch are carried over from p_onto_tree unchanged.
+CREATE OR REPLACE FUNCTION pggit.apply_inverse_diff(
+    p_repo_id INTEGER,
+    p_onto_tree TEXT,
+    p_old_tree TEXT,
+    p_new_tree TEXT
+) RETURNS TEXT SET search_path = pggit, public AS $$
+DECLARE
+    v_result JSONB;
+BEGIN
+    WITH onto_entries AS (
+        SELECT e->>'name' AS name, e AS entry
+        FROM pggit.trees t, jsonb_array_elements(t.entries) e
+        WHERE t.repo_id = p_repo_id AND t.hash = p_onto_tree
+    ),
+    old_entries AS (
+        SELECT e->>'name' AS name, e AS entry
+        FROM pggit.trees t, jsonb_array_elements(t.entries) e
+        WHERE t.repo_id = p_repo_id AND t.hash = p_old_tree
+    ),
+    delta AS (
+        SELECT d.change_type, d.path
+        FROM pggit.diff_trees(p_repo_id, p_old_tree, p_new_tree) d
+    ),
+    merged AS (
+        -- Carry over onto entries, but drop paths the delta added (reverting an
+        -- addition removes the file) and restore old contents for modified paths.
+        SELECT o.name,
+               CASE WHEN dl.change_type = 'modified'
+                        THEN (SELECT oe.entry FROM old_entries oe WHERE oe.name = o.name)
+                    ELSE o.entry
+               END AS entry
+        FROM onto_entries o
+        LEFT JOIN delta dl ON dl.path = o.name
+        WHERE dl.change_type IS DISTINCT FROM 'added'
+
+        UNION ALL
+
+        -- Restore files the delta deleted (present in old, absent in new) that
+        -- are not already present in the onto tree.
+        SELECT oe.name, oe.entry
+        FROM delta dl
+        JOIN old_entries oe ON oe.name = dl.path
+        WHERE dl.change_type = 'deleted'
+          AND NOT EXISTS (SELECT 1 FROM onto_entries o2 WHERE o2.name = dl.path)
+    )
+    SELECT jsonb_agg(entry ORDER BY name) INTO v_result FROM merged;
+
+    RETURN pggit.create_tree(p_repo_id, COALESCE(v_result, '[]'::jsonb));
+END;
+$$ LANGUAGE plpgsql;
+
 -- Revert implementation
 CREATE OR REPLACE FUNCTION pggit.revert(
     p_repo_id INTEGER,
@@ -43,20 +99,28 @@ CREATE OR REPLACE FUNCTION pggit.revert(
 DECLARE
     v_parent_tree TEXT;
     v_commit_tree TEXT;
+    v_head_tree TEXT;
     v_new_tree TEXT;
     v_new_commit TEXT;
     v_message TEXT;
 BEGIN
-    -- Get trees and message
+    -- Get the reverted commit's tree, its parent's tree, and its message.
     SELECT tree_hash, message,
            (SELECT tree_hash FROM commits WHERE repo_id = p_repo_id AND hash = c.parent_hash)
     INTO v_commit_tree, v_message, v_parent_tree
     FROM commits c
     WHERE c.repo_id = p_repo_id AND hash = p_commit_hash;
-    
-    -- Create inverse diff
-    v_new_tree := pggit.apply_inverse_diff(v_parent_tree, v_commit_tree);
-    
+
+    -- The revert applies on top of the current HEAD tree.
+    SELECT c.tree_hash INTO v_head_tree
+    FROM refs r
+    JOIN commits c ON c.repo_id = r.repo_id AND c.hash = r.commit_hash
+    WHERE r.repo_id = p_repo_id AND r.name = 'HEAD';
+
+    -- Reverse the parent->commit change onto HEAD.
+    v_new_tree := pggit.apply_inverse_diff(
+        p_repo_id, v_head_tree, v_parent_tree, v_commit_tree);
+
     -- Create revert commit
     v_new_commit := pggit.create_commit(
         p_repo_id,
@@ -65,12 +129,12 @@ BEGIN
         current_user,
         'Revert "' || v_message || '"'
     );
-    
+
     -- Update HEAD
     UPDATE refs
     SET commit_hash = v_new_commit
     WHERE repo_id = p_repo_id AND name = 'HEAD';
-    
+
     RETURN v_new_commit;
 END;
 $$ LANGUAGE plpgsql;

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -10,6 +10,7 @@ test/sql/merge_test.sql
 test/sql/merge_conflicts_test.sql
 test/sql/remote_test.sql
 test/sql/advanced_test.sql
+test/sql/revert_test.sql
 test/sql/reset_test.sql
 test/sql/search_path_qualification_test.sql
 test/sql/gc_test.sql

--- a/test/sql/revert_test.sql
+++ b/test/sql/revert_test.sql
@@ -1,0 +1,76 @@
+-- Path: /test/sql/revert_test.sql
+-- pg_git revert tests
+-- Regression: revert previously called a non-existent apply_inverse_diff and
+-- errored on every invocation.
+
+BEGIN;
+
+SELECT plan(5);
+
+SELECT pggit.init_repository('revert_repo', '/revert/path') AS repo_id \gset
+SELECT set_config('vars.repo_id', :'repo_id', false);
+
+-- c1: a.txt = v1
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'v1'::bytea)
+    AS blob_v1 \gset
+SELECT set_config('vars.blob_v1', :'blob_v1', false);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c1') AS c1 \gset
+SELECT set_config('vars.c1', :'c1', false);
+
+-- c2: a.txt -> v2, and add b.txt
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'a.txt', 'v2'::bytea);
+SELECT pggit.stage_file((current_setting('vars.repo_id')::int), 'b.txt', 'new'::bytea);
+SELECT pggit.commit_index((current_setting('vars.repo_id')::int), 'tester', 'c2') AS c2 \gset
+SELECT set_config('vars.c2', :'c2', false);
+
+-- Revert c2. Reversing the c1->c2 delta onto HEAD undoes both changes.
+SELECT pggit.revert((current_setting('vars.repo_id')::int), current_setting('vars.c2'))
+    AS revert_commit \gset
+SELECT set_config('vars.revert_commit', :'revert_commit', false);
+
+-- A fresh commit was created (distinct from the reverted one).
+SELECT isnt(
+    current_setting('vars.revert_commit'),
+    current_setting('vars.c2'),
+    'revert creates a new commit'
+);
+
+-- HEAD advanced to the revert commit.
+SELECT is(
+    (SELECT commit_hash FROM refs
+     WHERE repo_id = (current_setting('vars.repo_id')::int) AND name = 'HEAD'),
+    current_setting('vars.revert_commit'),
+    'HEAD points at the revert commit'
+);
+
+SELECT tree_hash AS revert_tree FROM commits WHERE hash = :'revert_commit' \gset
+SELECT set_config('vars.revert_tree', :'revert_tree', false);
+
+-- a.txt is restored to its pre-c2 (v1) content.
+SELECT is(
+    (SELECT blob_hash FROM pggit.get_tree_files(
+        (current_setting('vars.repo_id')::int), current_setting('vars.revert_tree')) gtf
+     WHERE gtf.path = 'a.txt'),
+    current_setting('vars.blob_v1'),
+    'revert restores a file modified by the reverted commit'
+);
+
+-- b.txt, which c2 added, is removed by the revert.
+SELECT is_empty(
+    $$SELECT 1 FROM pggit.get_tree_files(
+        (current_setting('vars.repo_id')::int), current_setting('vars.revert_tree')) gtf
+      WHERE gtf.path = 'b.txt'$$,
+    'revert removes a file added by the reverted commit'
+);
+
+-- The reverted tree contains exactly the surviving file.
+SELECT results_eq(
+    $$SELECT gtf.path FROM pggit.get_tree_files(
+        (current_setting('vars.repo_id')::int), current_setting('vars.revert_tree')) gtf
+      ORDER BY gtf.path$$,
+    $$VALUES ('a.txt')$$,
+    'revert yields the expected tree'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

`pggit.revert` called `pggit.apply_inverse_diff(parent_tree, commit_tree)` — a function that was **never defined** — so every revert failed with `function pggit.apply_inverse_diff(text, text) does not exist`.

## Fix

- Add `pggit.apply_inverse_diff(p_repo_id, p_onto_tree, p_old_tree, p_new_tree)`: it takes the *onto* tree and reverses the `old -> new` delta — a file the delta **added** is removed, a file it **modified** or **deleted** is restored to its `old_tree` contents, and paths the delta didn't touch are carried over unchanged.
- `revert` now resolves the current HEAD tree and reverses the reverted commit's `parent -> commit` change onto it (rather than relying on a two-argument helper that couldn't see HEAD).

## Tests

`test/sql/revert_test.sql` (5 assertions): reverting a commit that modified `a.txt` and added `b.txt` restores `a.txt` to its earlier content, drops `b.txt`, advances HEAD to the revert commit, and yields exactly the expected tree. Wired into the core suite.

## Verification

`make test-core` — PASS (full suite green against PostgreSQL 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah3utcCy6BGmEZ4kG9XEGS)_