### PR TITLE
Fix collect_diagnostics: remove missing pggit.config reference and scope counts per repo

### DIFF
--- a/makefile
+++ b/makefile
@@ -62,6 +62,7 @@ CORE_TESTS := \
        test/sql/merge_conflicts_test.sql \
        test/sql/remote_test.sql \
        test/sql/advanced_test.sql \
+       test/sql/diagnose_test.sql \
        test/sql/reset_test.sql \
        test/sql/search_path_qualification_test.sql \
        test/sql/gc_test.sql \

--- a/sql/pg_git--0.4.0.sql
+++ b/sql/pg_git--0.4.0.sql
@@ -1898,23 +1898,26 @@ DECLARE
     v_report_id INTEGER;
     v_report_data JSONB;
 BEGIN
-    -- Collect repository info
+    -- Collect repository info. Object counts are scoped to this repository so
+    -- the report reflects the requested repo rather than the whole install.
     WITH repo_info AS (
         SELECT r.*,
-               (SELECT COUNT(*) FROM commits c) as commit_count,
-               (SELECT COUNT(*) FROM blobs b) as blob_count,
-               (SELECT COUNT(*) FROM trees t) as tree_count,
-               (SELECT COUNT(*) FROM refs rf) as ref_count
+               (SELECT COUNT(*) FROM commits c WHERE c.repo_id = p_repo_id) as commit_count,
+               (SELECT COUNT(*) FROM blobs b WHERE b.repo_id = p_repo_id) as blob_count,
+               (SELECT COUNT(*) FROM trees t WHERE t.repo_id = p_repo_id) as tree_count,
+               (SELECT COUNT(*) FROM refs rf WHERE rf.repo_id = p_repo_id) as ref_count
         FROM repositories r
         WHERE id = p_repo_id
     ),
-    -- Collect size info
+    -- Collect size info (scoped to this repository).
     size_info AS (
         SELECT 'blobs' as type, pg_size_pretty(sum(octet_length(content))) as total_size
         FROM blobs
+        WHERE repo_id = p_repo_id
         UNION ALL
         SELECT 'trees', pg_size_pretty(sum(octet_length(entries::text)))
         FROM trees
+        WHERE repo_id = p_repo_id
     ),
     -- Collect performance metrics
     perf_metrics AS (
@@ -1928,19 +1931,16 @@ BEGIN
         FROM pggit.verify_integrity(p_repo_id)
         GROUP BY status
     )
+    -- Each section is built with a scalar subquery so the aggregated sections
+    -- (sizes, errors) do not have to share a GROUP BY with the single-row
+    -- repository/performance sections.
     SELECT jsonb_build_object(
-        'repository', row_to_json(repo_info),
-        'sizes', jsonb_agg(to_jsonb(size_info)),
-        'performance', to_jsonb(perf_metrics),
-        'errors', jsonb_agg(to_jsonb(error_info)),
-        'configs', (
-            SELECT jsonb_object_agg(key, value)
-            FROM pggit.config
-            WHERE repo_id = p_repo_id
-        )
+        'repository', (SELECT row_to_json(repo_info) FROM repo_info),
+        'sizes',      (SELECT jsonb_agg(to_jsonb(size_info)) FROM size_info),
+        'performance',(SELECT to_jsonb(perf_metrics) FROM perf_metrics),
+        'errors',     (SELECT jsonb_agg(to_jsonb(error_info)) FROM error_info)
     )
-    INTO v_report_data
-    FROM repo_info, size_info, perf_metrics, error_info;
+    INTO v_report_data;
 
     -- Store report
     INSERT INTO pggit.diagnostic_reports (repo_id, report_type, report_data)
@@ -1978,10 +1978,6 @@ BEGIN
     UNION ALL
     SELECT 'Error Summary',
            jsonb_pretty(report_data->'errors')
-    FROM report
-    UNION ALL
-    SELECT 'Configuration',
-           jsonb_pretty(report_data->'configs')
     FROM report;
 END;
 $$ LANGUAGE plpgsql;

--- a/sql/pgit-diagnose.sql
+++ b/sql/pgit-diagnose.sql
@@ -16,23 +16,26 @@ DECLARE
     v_report_id INTEGER;
     v_report_data JSONB;
 BEGIN
-    -- Collect repository info
+    -- Collect repository info. Object counts are scoped to this repository so
+    -- the report reflects the requested repo rather than the whole install.
     WITH repo_info AS (
         SELECT r.*,
-               (SELECT COUNT(*) FROM commits c) as commit_count,
-               (SELECT COUNT(*) FROM blobs b) as blob_count,
-               (SELECT COUNT(*) FROM trees t) as tree_count,
-               (SELECT COUNT(*) FROM refs rf) as ref_count
+               (SELECT COUNT(*) FROM commits c WHERE c.repo_id = p_repo_id) as commit_count,
+               (SELECT COUNT(*) FROM blobs b WHERE b.repo_id = p_repo_id) as blob_count,
+               (SELECT COUNT(*) FROM trees t WHERE t.repo_id = p_repo_id) as tree_count,
+               (SELECT COUNT(*) FROM refs rf WHERE rf.repo_id = p_repo_id) as ref_count
         FROM repositories r
         WHERE id = p_repo_id
     ),
-    -- Collect size info
+    -- Collect size info (scoped to this repository).
     size_info AS (
         SELECT 'blobs' as type, pg_size_pretty(sum(octet_length(content))) as total_size
         FROM blobs
+        WHERE repo_id = p_repo_id
         UNION ALL
         SELECT 'trees', pg_size_pretty(sum(octet_length(entries::text)))
         FROM trees
+        WHERE repo_id = p_repo_id
     ),
     -- Collect performance metrics
     perf_metrics AS (
@@ -46,19 +49,16 @@ BEGIN
         FROM pggit.verify_integrity(p_repo_id)
         GROUP BY status
     )
+    -- Each section is built with a scalar subquery so the aggregated sections
+    -- (sizes, errors) do not have to share a GROUP BY with the single-row
+    -- repository/performance sections.
     SELECT jsonb_build_object(
-        'repository', row_to_json(repo_info),
-        'sizes', jsonb_agg(to_jsonb(size_info)),
-        'performance', to_jsonb(perf_metrics),
-        'errors', jsonb_agg(to_jsonb(error_info)),
-        'configs', (
-            SELECT jsonb_object_agg(key, value)
-            FROM pggit.config
-            WHERE repo_id = p_repo_id
-        )
+        'repository', (SELECT row_to_json(repo_info) FROM repo_info),
+        'sizes',      (SELECT jsonb_agg(to_jsonb(size_info)) FROM size_info),
+        'performance',(SELECT to_jsonb(perf_metrics) FROM perf_metrics),
+        'errors',     (SELECT jsonb_agg(to_jsonb(error_info)) FROM error_info)
     )
-    INTO v_report_data
-    FROM repo_info, size_info, perf_metrics, error_info;
+    INTO v_report_data;
 
     -- Store report
     INSERT INTO pggit.diagnostic_reports (repo_id, report_type, report_data)
@@ -96,10 +96,6 @@ BEGIN
     UNION ALL
     SELECT 'Error Summary',
            jsonb_pretty(report_data->'errors')
-    FROM report
-    UNION ALL
-    SELECT 'Configuration',
-           jsonb_pretty(report_data->'configs')
     FROM report;
 END;
 $$ LANGUAGE plpgsql;

--- a/test/sql/diagnose_test.sql
+++ b/test/sql/diagnose_test.sql
@@ -1,0 +1,65 @@
+-- Path: /test/sql/diagnose_test.sql
+-- pg_git diagnostics tests
+-- Regression: collect_diagnostics referenced a non-existent pggit.config table
+-- (and mixed aggregates without a GROUP BY), so it errored on every call. It
+-- also counted objects across all repositories rather than the requested one.
+
+BEGIN;
+
+SELECT plan(5);
+
+-- Two repositories with different object counts, to prove per-repo scoping.
+SELECT pggit.init_repository('diag_one', '/diag/one') AS r1 \gset
+SELECT set_config('vars.r1', :'r1', false);
+SELECT pggit.init_repository('diag_two', '/diag/two') AS r2 \gset
+SELECT set_config('vars.r2', :'r2', false);
+
+-- r1: a single commit (plus the initial commit created by init).
+SELECT pggit.stage_file((current_setting('vars.r1')::int), 'a.txt', 'aaa'::bytea);
+SELECT pggit.commit_index((current_setting('vars.r1')::int), 'tester', 'r1c1');
+
+-- r2: two extra commits and more blobs.
+SELECT pggit.stage_file((current_setting('vars.r2')::int), 'x.txt', 'xxx'::bytea);
+SELECT pggit.commit_index((current_setting('vars.r2')::int), 'tester', 'r2c1');
+SELECT pggit.stage_file((current_setting('vars.r2')::int), 'y.txt', 'yyy'::bytea);
+SELECT pggit.commit_index((current_setting('vars.r2')::int), 'tester', 'r2c2');
+
+-- collect_diagnostics runs and returns a report id.
+SELECT pggit.collect_diagnostics((current_setting('vars.r1')::int)) AS report_id \gset
+SELECT set_config('vars.report_id', :'report_id', false);
+SELECT isnt(
+    (SELECT :'report_id'::int), NULL,
+    'collect_diagnostics returns a report id'
+);
+
+-- A report row was stored.
+SELECT is(
+    (SELECT count(*)::int FROM pggit.diagnostic_reports
+     WHERE id = (current_setting('vars.report_id')::int)),
+    1,
+    'collect_diagnostics stores the report'
+);
+
+-- Counts are scoped to r1 (init commit + one commit == 2), not the whole install.
+SELECT is(
+    (SELECT (report_data->'repository'->>'commit_count')::int
+     FROM pggit.diagnostic_reports WHERE id = (current_setting('vars.report_id')::int)),
+    2,
+    'commit_count is scoped to the target repository'
+);
+SELECT is(
+    (SELECT (report_data->'repository'->>'blob_count')::int
+     FROM pggit.diagnostic_reports WHERE id = (current_setting('vars.report_id')::int)),
+    1,
+    'blob_count is scoped to the target repository'
+);
+
+-- get_diagnostic_report renders the stored sections.
+SELECT isnt_empty(
+    $$SELECT * FROM pggit.get_diagnostic_report((current_setting('vars.report_id')::int))
+      WHERE section = 'Repository Info'$$,
+    'get_diagnostic_report returns the repository section'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/test/sql/manifest.txt
+++ b/test/sql/manifest.txt
@@ -10,6 +10,7 @@ test/sql/merge_test.sql
 test/sql/merge_conflicts_test.sql
 test/sql/remote_test.sql
 test/sql/advanced_test.sql
+test/sql/diagnose_test.sql
 test/sql/reset_test.sql
 test/sql/search_path_qualification_test.sql
 test/sql/gc_test.sql


### PR DESCRIPTION
## Summary

`collect_diagnostics` errored on **every** call (`relation "pggit.config" does not exist`), and a second latent bug lurked behind it.

## Bugs fixed

- **Missing table** — the report's `configs` section selected from `pggit.config`, which does not exist anywhere in the schema. Removed that section (and the matching branch in `get_diagnostic_report`).
- **Aggregate/GROUP BY error** — once the query could plan, the final `SELECT` mixed aggregates (`jsonb_agg(...)`) with non-aggregated columns (`row_to_json(repo_info)`, `to_jsonb(perf_metrics)`) over a cross join, raising `column "repo_info.*" must appear in the GROUP BY clause`. Each JSON section is now built with a scalar subquery, so the aggregated sections no longer share a GROUP BY with the single-row sections.
- **Cross-repo counts** — object counts and size sums covered every repository in the install. They are now scoped to the requested `p_repo_id`.

## Tests

`test/sql/diagnose_test.sql` (5 assertions) sets up two repositories and asserts the report is produced, stored, and rendered, and that `commit_count`/`blob_count` reflect only the target repo (not the other one's objects). Wired into the core suite.

## Verification

`make test-core` — PASS (full suite green against PostgreSQL 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah3utcCy6BGmEZ4kG9XEGS)_